### PR TITLE
TFKUBE-118: Fix database connection timeout issue

### DIFF
--- a/pkg/modules/AWS/eks/outputs.tf
+++ b/pkg/modules/AWS/eks/outputs.tf
@@ -34,5 +34,5 @@ output "kubernetes_provider_config" {
 }
 
 output "cluster_security_group" {
-  value = module.eks.cluster_security_group_id
+  value = module.eks.cluster_primary_security_group_id
 }


### PR DESCRIPTION
Updated EKS output cluster_security_group so that RDS instance can create security group inbound rule correctly.