### PR TITLE
Silence the curl request

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -207,6 +207,7 @@ set_current_context_k8s() {
 resume_bamboo_server() {
   # Please note that if you import the dataset, make sure admin credential in config file (config.tfvars)
   # is matched with admin info stored in dataset you import. 
+  log "Resuming Bamboo server."
   BAMBOO_DATASET=$(get_variable 'dataset_url' "${CONFIG_ABS_PATH}")
   local SERVER_STATUS=
 
@@ -230,11 +231,14 @@ resume_bamboo_server() {
       fi
       bamboo_url=$(terraform output | grep '"bamboo" =' | sed -nE 's/^.*"(.*)".*$/\1/p')
       resume_bamboo_url="${bamboo_url}/rest/api/latest/server/resume"
-      local RESULT=$(curl -u "${ADMIN_USERNAME}:${ADMIN_PASSWORD}" -X POST "${resume_bamboo_url}")
+      local RESULT=$(curl -s -u "${ADMIN_USERNAME}:${ADMIN_PASSWORD}" -X POST "${resume_bamboo_url}")
       if [[ "x${RESULT}" == *"RUNNING"* ]]; then
         SERVER_STATUS="RUNNING"
+        log "Bamboo server was resumed and it is running successfully."
       elif [ "x${RESULT}" == *"AUTHENTICATED_FAILED"* ]; then
         log "The provided admin username and password is not matched with the credential stored in the dataset." "ERROR"
+      else
+        log "Unexpected state when resuming Bamboo server, state: ${RESULT}" "ERROR"
       fi
     fi
     if [ -z $SERVER_STATUS ]; then


### PR DESCRIPTION
* Resume the `curl` output so it doesn't break the flow of log messages
* Add some logging for the resume Bamboo server action