### PR TITLE
Fix Synchrony URL pattern

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -254,7 +254,7 @@ set_synchrony_url() {
 
   if [ -z "${DOMAIN}" ] && [ -n "${INSTALL_CONFLUENCE}" ]; then
     log "Configuring the Synchrony service."
-    SYNCHRONY_FULL_URL=$(terraform output | grep 'synchrony_url =' | sed -nE 's/^.*"(.*)".*$/\1/p')
+    SYNCHRONY_FULL_URL=$(terraform output | sed "s/ //g" | grep "synchrony_url=" | sed -nE 's/^.*"(.*)".*$/\1/p')
     helm upgrade confluence atlassian-data-center/confluence -n atlassian --reuse-values --set synchrony.ingressUrl="${SYNCHRONY_FULL_URL}" > /dev/null
     log "Synchrony URL is set to '${SYNCHRONY_FULL_URL}'."
   fi

--- a/install.sh
+++ b/install.sh
@@ -254,7 +254,7 @@ set_synchrony_url() {
 
   if [ -z "${DOMAIN}" ] && [ -n "${INSTALL_CONFLUENCE}" ]; then
     log "Configuring the Synchrony service."
-    SYNCHRONY_FULL_URL=$(terraform output | grep '"synchrony" =' | sed -nE 's/^.*"(.*)".*$/\1/p')
+    SYNCHRONY_FULL_URL=$(terraform output | grep 'synchrony_url =' | sed -nE 's/^.*"(.*)".*$/\1/p')
     helm upgrade confluence atlassian-data-center/confluence -n atlassian --reuse-values --set synchrony.ingressUrl="${SYNCHRONY_FULL_URL}" > /dev/null
     log "Synchrony URL is set to '${SYNCHRONY_FULL_URL}'."
   fi


### PR DESCRIPTION
Now it sets the Synchrony correctly:
```
2022-02-18 17:51:53 [INFO] Resource tags are applied to ASG and all EC2 instances.
2022-02-18 17:51:53 [INFO] Configuring the Synchrony service.
2022-02-18 17:52:10 [INFO] Synchrony URL is set to 'http://a1fe4e953a927473e86e11ad6bb49413-1810032194.ap-southeast-1.elb.amazonaws.com/synchrony'.
```