### PR TITLE
TFKUBE-201: Add cluster-autoscaler

### DIFF
--- a/config.tfvars
+++ b/config.tfvars
@@ -33,7 +33,11 @@ resource_tags = {
 # Instance types that is preferred for EKS node group.
 instance_types = ["m5.2xlarge"]
 
-# Desired number of nodes that the node group should launch with initially.
+# Desired number of nodes that the node group should launch with initially. This value cannot be changed later.
+# There is an cluster-autoscaler installed on the EKS cluster that will manage the requested capacity
+# and increase/decrease the number of nodes accordingly. This ensures there is always enough resources for the workloads
+# and removes the need to change this value.
+# https://github.com/terraform-aws-modules/terraform-aws-eks/blob/v17.24.0/docs/faq.md#why-does-changing-the-node-or-worker-groups-desired-count-not-do-anything
 desired_capacity = 1
 
 ################################################################################

--- a/config.tfvars
+++ b/config.tfvars
@@ -34,7 +34,7 @@ resource_tags = {
 instance_types = ["m5.2xlarge"]
 
 # Desired number of nodes that the node group should launch with initially. This value cannot be changed later.
-# There is an cluster-autoscaler installed on the EKS cluster that will manage the requested capacity
+# There is a cluster-autoscaler installed on the EKS cluster that will manage the requested capacity
 # and increase/decrease the number of nodes accordingly. This ensures there is always enough resources for the workloads
 # and removes the need to change this value.
 # https://github.com/terraform-aws-modules/terraform-aws-eks/blob/v17.24.0/docs/faq.md#why-does-changing-the-node-or-worker-groups-desired-count-not-do-anything

--- a/docs/docs/development/HOW_TO_TEST.md
+++ b/docs/docs/development/HOW_TO_TEST.md
@@ -33,8 +33,8 @@ See the [How to start development guide](HOW_TO_START.md) for details on how you
     To run unit tests, use the following commands:
     
     ```shell
-    cd test && go get -v -t -d ./... && go mod tidy
-    go test ./unittest/... -v
+    go get -v -t -d ./... && go mod tidy
+    go test ./test/unittest/... -v
     ```
     
     You can use `regex` keywords to run specific groups of test cases. For example, you can run only `VPC` module-related tests with `go test ./unittest/... -v -run TestVpc`.
@@ -45,9 +45,9 @@ See the [How to start development guide](HOW_TO_START.md) for details on how you
     
     ```shell
     export TF_VAR_bamboo_license='<bamboo-license>'
-    cd test && mkdir ./e2etest/artifacts
+    mkdir -p ./test/e2etest/artifacts
     go get -v -t -d ./... && go mod tidy
-    go test ./e2etest -v -timeout 60m -run Installer | tee ./e2etest/artifacts/e2etest.log
+    go test ./test/e2etest -v -timeout 60m -run Installer | tee ./test/e2etest/artifacts/e2etest.log
     ```
 ## GitHub Actions
 

--- a/modules/AWS/efs/main.tf
+++ b/modules/AWS/efs/main.tf
@@ -53,7 +53,7 @@ data "aws_iam_policy_document" "this" {
 
 module "efs_iam_role" {
   source       = "terraform-aws-modules/iam/aws//modules/iam-assumable-role-with-oidc"
-  version      = "3.6.0"
+  version      = "4.13.2"
   create_role  = true
   role_name    = "${var.eks.cluster_name}-${local.efs_csi_name}"
   provider_url = replace(var.eks.cluster_oidc_issuer_url, "https://", "")
@@ -87,7 +87,7 @@ resource "helm_release" "efs_csi" {
       serviceAccount = {
         name = local.efs_csi_serviceAccount_name
         annotations = {
-          "eks.amazonaws.com/role-arn" : module.efs_iam_role.this_iam_role_arn
+          "eks.amazonaws.com/role-arn" : module.efs_iam_role.iam_role_arn
         }
       }
     }
@@ -136,7 +136,6 @@ resource "aws_security_group" "this" {
     cidr_blocks = ["0.0.0.0/0"]
   }
 }
-
 
 resource "aws_efs_file_system" "this" {
   creation_token = var.eks.cluster_name

--- a/modules/AWS/eks/autoscaling.tf
+++ b/modules/AWS/eks/autoscaling.tf
@@ -1,0 +1,102 @@
+module "autoscaler_iam_role" {
+  source  = "terraform-aws-modules/iam/aws//modules/iam-assumable-role-with-oidc"
+  version = "4.13.2"
+
+  create_role  = true
+  role_name    = "${var.cluster_name}-cluster-autoscaler"
+  provider_url = replace(module.eks.cluster_oidc_issuer_url, "https://", "")
+
+  role_policy_arns = [
+    aws_iam_policy.cluster_autoscaler.arn
+  ]
+  oidc_fully_qualified_subjects = [
+    "system:serviceaccount:${local.autoscaler_service_account_namespace}:${local.autoscaler_service_account_name}"
+  ]
+}
+
+resource "aws_iam_policy" "cluster_autoscaler" {
+  name_prefix = "cluster-autoscaler"
+  description = "EKS cluster-autoscaler policy for cluster ${module.eks.cluster_id}"
+  policy      = data.aws_iam_policy_document.cluster_autoscaler.json
+}
+
+data "aws_iam_policy_document" "cluster_autoscaler" {
+  statement {
+    sid    = "clusterAutoscalerAll"
+    effect = "Allow"
+
+    actions = [
+      "autoscaling:DescribeAutoScalingGroups",
+      "autoscaling:DescribeAutoScalingInstances",
+      "autoscaling:DescribeLaunchConfigurations",
+      "autoscaling:DescribeTags",
+      "ec2:DescribeLaunchTemplateVersions",
+      "ec2:DescribeInstanceTypes"
+    ]
+
+    resources = [
+      "*"
+    ]
+  }
+
+  statement {
+    sid    = "clusterAutoscalerOwn"
+    effect = "Allow"
+
+    actions = [
+      "autoscaling:SetDesiredCapacity",
+      "autoscaling:TerminateInstanceInAutoScalingGroup",
+      "autoscaling:UpdateAutoScalingGroup",
+    ]
+
+    resources = [
+      "*"
+    ]
+
+    condition {
+      test     = "StringEquals"
+      variable = "autoscaling:ResourceTag/kubernetes.io/cluster/${module.eks.cluster_id}"
+      values = [
+        "owned"
+      ]
+    }
+
+    condition {
+      test     = "StringEquals"
+      variable = "autoscaling:ResourceTag/k8s.io/cluster-autoscaler/enabled"
+      values = [
+        "true"
+      ]
+    }
+  }
+}
+
+resource "helm_release" "cluster-autoscaler" {
+  depends_on = [
+    module.eks
+  ]
+
+  name       = "cluster-autoscaler"
+  namespace  = local.autoscaler_service_account_namespace
+  repository = "https://kubernetes.github.io/autoscaler"
+  chart      = "cluster-autoscaler"
+  version    = local.autoscaler_version
+
+  values = [yamlencode({
+    awsRegion = var.region
+    rbac = {
+      create = true
+      serviceAccount = {
+        name = local.autoscaler_service_account_name
+        annotations = {
+          "eks.amazonaws.com/role-arn" : module.autoscaler_iam_role.iam_role_arn
+        }
+      }
+    }
+    autoDiscovery = {
+      enabled     = true
+      clusterName = var.cluster_name
+    }
+  })]
+}
+

--- a/modules/AWS/eks/autoscaling.tf
+++ b/modules/AWS/eks/autoscaling.tf
@@ -3,7 +3,7 @@ module "autoscaler_iam_role" {
   version = "4.13.2"
 
   create_role  = true
-  role_name    = "${var.cluster_name}-cluster-autoscaler"
+  role_name    = "${var.cluster_name}-autoscaler"
   provider_url = replace(module.eks.cluster_oidc_issuer_url, "https://", "")
 
   role_policy_arns = [

--- a/modules/AWS/eks/locals.tf
+++ b/modules/AWS/eks/locals.tf
@@ -3,4 +3,9 @@ locals {
   # When the framework get uninstalled, there is no appNode attribute for node_group and so next install will break
   # because eks is still is not created but terraform tries to evaluate the cluster_asg_name
   cluster_asg_name = try(module.eks.node_groups.appNodes.resources[0].autoscaling_groups[0].name, null)
+
+  autoscaler_service_account_namespace = "kube-system"
+  autoscaler_service_account_name      = "cluster-autoscaler-aws-cluster-autoscaler-chart"
+
+  autoscaler_version = "9.16.0"
 }

--- a/modules/AWS/eks/main.tf
+++ b/modules/AWS/eks/main.tf
@@ -1,11 +1,13 @@
 module "eks" {
   source  = "terraform-aws-modules/eks/aws"
-  version = "17.23.0"
+  version = "17.24.0"
 
   # Configure cluster
   cluster_version              = "1.21"
   cluster_name                 = var.cluster_name
   manage_cluster_iam_resources = true
+
+  enable_irsa = true
 
   # Networking
   vpc_id  = var.vpc_id
@@ -14,7 +16,7 @@ module "eks" {
   # These 2 properties below will be deprecated in v18 of the AWS EKS module:
   # https://github.com/terraform-aws-modules/terraform-aws-eks/blob/master/UPGRADE-18.0.md
   # If upgrading this module to v18 be sure that this deprecation is taken into account.
-  kubeconfig_aws_authenticator_command = "aws"
+  kubeconfig_aws_authenticator_command      = "aws"
   kubeconfig_aws_authenticator_command_args = ["eks", "get-token", "--cluster-name", var.cluster_name]
 
   # Managed Node Groups
@@ -25,11 +27,12 @@ module "eks" {
 
   node_groups = {
     appNodes = {
-      name             = "appNode"
+      name             = "appNode-${replace(join("-", var.instance_types), ".", "_")}"
       desired_capacity = var.desired_capacity
       max_capacity     = 10
       min_capacity     = 1
 
+      subnets        = slice(var.subnets, 0, 1)
       instance_types = var.instance_types
       capacity_type  = "ON_DEMAND"
     }

--- a/modules/AWS/eks/main.tf
+++ b/modules/AWS/eks/main.tf
@@ -7,6 +7,8 @@ module "eks" {
   cluster_name                 = var.cluster_name
   manage_cluster_iam_resources = true
 
+  # Enables IAM roles for service accounts - required for autoscaler
+  # https://docs.aws.amazon.com/eks/latest/userguide/iam-roles-for-service-accounts.html
   enable_irsa = true
 
   # Networking

--- a/modules/AWS/eks/providers.tf
+++ b/modules/AWS/eks/providers.tf
@@ -11,3 +11,11 @@ provider "kubernetes" {
   token                  = data.aws_eks_cluster_auth.cluster.token
   cluster_ca_certificate = base64decode(data.aws_eks_cluster.cluster.certificate_authority.0.data)
 }
+
+provider "helm" {
+  kubernetes {
+    host                   = data.aws_eks_cluster.cluster.endpoint
+    token                  = data.aws_eks_cluster_auth.cluster.token
+    cluster_ca_certificate = base64decode(data.aws_eks_cluster.cluster.certificate_authority.0.data)
+  }
+}

--- a/modules/AWS/eks/variables.tf
+++ b/modules/AWS/eks/variables.tf
@@ -7,6 +7,11 @@ variable "cluster_name" {
   }
 }
 
+variable "region" {
+  description = "Region of the EKS cluster."
+  type        = string
+}
+
 variable "vpc_id" {
   description = "VPC where the cluster and workers will be deployed."
   type        = string

--- a/modules/common/main.tf
+++ b/modules/common/main.tf
@@ -7,6 +7,8 @@ module "vpc" {
 module "eks" {
   source = "../AWS/eks"
 
+  region = var.region_name
+
   cluster_name = local.cluster_name
 
   vpc_id  = module.vpc.vpc_id
@@ -19,11 +21,13 @@ module "eks" {
 module "efs" {
   source = "../AWS/efs"
 
-  efs_name                     = local.efs_name
-  region_name                  = var.region_name
-  vpc                          = module.vpc
-  eks                          = module.eks
-  csi_controller_replica_count = var.desired_capacity
+  efs_name    = local.efs_name
+  region_name = var.region_name
+  vpc         = module.vpc
+  eks         = module.eks
+
+  // Having up to two replicas for the EFS controller should be enough
+  csi_controller_replica_count = var.desired_capacity >= 2 ? 2 : 1
 }
 
 module "ingress" {

--- a/modules/products/bitbucket/helm.tf
+++ b/modules/products/bitbucket/helm.tf
@@ -6,6 +6,7 @@ resource "helm_release" "bitbucket" {
   repository = local.helm_chart_repository
   chart      = local.product_name
   version    = local.bitbucket_helm_chart_version
+  timeout    = 10 * 60 # autoscaler potentially needs to scale up the cluster
 
   values = [
     yamlencode({

--- a/modules/products/confluence/helm.tf
+++ b/modules/products/confluence/helm.tf
@@ -7,7 +7,7 @@ resource "helm_release" "confluence" {
   repository = local.helm_chart_repository
   chart      = local.confluence_helm_chart_name
   version    = local.confluence_helm_chart_version
-  timeout    = 10 * 60
+  timeout    = 10 * 60 # autoscaler potentially needs to scale up the cluster
 
   values = [
     yamlencode({

--- a/modules/products/jira/helm.tf
+++ b/modules/products/jira/helm.tf
@@ -6,6 +6,7 @@ resource "helm_release" "jira" {
   repository = local.helm_chart_repository
   chart      = local.product_name
   version    = local.jira_helm_chart_version
+  timeout    = 10 * 60 # autoscaler potentially needs to scale up the cluster
 
   values = [
     yamlencode({

--- a/modules/tfstate/main.tf
+++ b/modules/tfstate/main.tf
@@ -1,5 +1,13 @@
 # This file deals with where Terraform is keeping its state in AWS.
 # Please note that this file will run by `install.sh' and no need to run manually.
+terraform {
+  required_providers {
+    aws = {
+      version = "~> 3.74"
+    }
+  }
+}
+
 provider "aws" {
   region = var.region
 }

--- a/providers.tf
+++ b/providers.tf
@@ -1,3 +1,17 @@
+terraform {
+  required_providers {
+    aws = {
+      version = "~> 3.74"
+    }
+    kubernetes = {
+      version = "~> 2.7"
+    }
+    helm = {
+      version = "~> 2.4"
+    }
+  }
+}
+
 provider "aws" {
   region = var.region
   // This will allow an AWS provider to add the resource tags to every AWS resources except ASG resources (See https://learn.hashicorp.com/tutorials/terraform/aws-default-tags?in=terraform/aws)

--- a/test/e2etest/bitbucket_test.go
+++ b/test/e2etest/bitbucket_test.go
@@ -4,14 +4,15 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
-	"github.com/go-git/go-git/v5"
-	"github.com/go-git/go-git/v5/plumbing/transport/ssh"
-	"github.com/gruntwork-io/terratest/modules/k8s"
-	"github.com/stretchr/testify/assert"
 	"io/ioutil"
 	"os"
 	"os/exec"
 	"testing"
+
+	"github.com/go-git/go-git/v5"
+	"github.com/go-git/go-git/v5/plumbing/transport/ssh"
+	"github.com/gruntwork-io/terratest/modules/k8s"
+	"github.com/stretchr/testify/assert"
 )
 
 func bitbucketHealthTests(t *testing.T, testConfig TestConfig) {
@@ -32,9 +33,7 @@ func assertBitbucketStatusEndpoint(t *testing.T, testConfig TestConfig) {
 func assertBitbucketNfsConnectivity(t *testing.T, testConfig TestConfig) {
 	println("Asserting Bitbucket NFS connectivity ...")
 
-	contextName := fmt.Sprintf("eks_atlas-%s-cluster", testConfig.EnvironmentName)
-	kubeConfigPath := fmt.Sprintf("../../kubeconfig_atlas-%s-cluster", testConfig.EnvironmentName)
-	kubectlOptions := k8s.NewKubectlOptions(contextName, kubeConfigPath, "atlassian")
+	kubectlOptions := getKubectlOptions(testConfig)
 
 	// Write a file to the NFS server
 	returnCode, kubectlError := k8s.RunKubectlAndGetOutputE(t, kubectlOptions,

--- a/test/e2etest/cluster_test.go
+++ b/test/e2etest/cluster_test.go
@@ -1,0 +1,23 @@
+package e2etest
+
+import (
+	"testing"
+
+	"github.com/gruntwork-io/terratest/modules/k8s"
+	"github.com/stretchr/testify/assert"
+)
+
+func clusterHealthTests(t *testing.T, testConfig TestConfig) {
+	printTestBanner("Cluster", "Tests")
+
+	config := getKubectlOptions(testConfig)
+	nodes := k8s.GetNodes(t, config)
+
+	// kubectl describe deployments cluster-autoscaler-aws-cluster-autoscaler -n kube-system
+	output, err := k8s.RunKubectlAndGetOutputE(t, config, "describe", "deployments", "cluster-autoscaler-aws-cluster-autoscaler", "-n", "kube-system")
+
+	assert.NoError(t, err)
+	assert.Contains(t, output, "1 available")
+
+	assert.Equal(t, expectedNumberOfNodes, len(nodes), "Expected 3 nodes in the cluster")
+}

--- a/test/e2etest/helper.go
+++ b/test/e2etest/helper.go
@@ -2,8 +2,6 @@ package e2etest
 
 import (
 	"fmt"
-	"github.com/gruntwork-io/terratest/modules/random"
-	"github.com/stretchr/testify/assert"
 	"io"
 	"log"
 	"net/http"
@@ -15,6 +13,9 @@ import (
 
 	"github.com/aws/aws-sdk-go/aws/endpoints"
 	"github.com/gruntwork-io/terratest/modules/aws"
+	"github.com/gruntwork-io/terratest/modules/k8s"
+	"github.com/gruntwork-io/terratest/modules/random"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -32,6 +33,9 @@ const (
 	confluenceLicense = ""
 	bitbucketLicense  = ""
 	bambooLicense     = ""
+
+	// If there is a change in the computational requests, this value should be updated
+	expectedNumberOfNodes = 3
 )
 
 type TestConfig struct {
@@ -165,6 +169,13 @@ func createConfig(t *testing.T, productList []string) TestConfig {
 
 	testConfig.ConfigPath = filePath
 	return testConfig
+}
+
+func getKubectlOptions(testConfig TestConfig) *k8s.KubectlOptions {
+	contextName := fmt.Sprintf("eks_atlas-%s-cluster", testConfig.EnvironmentName)
+	kubeConfigPath := fmt.Sprintf("../../kubeconfig_atlas-%s-cluster", testConfig.EnvironmentName)
+	kubectlOptions := k8s.NewKubectlOptions(contextName, kubeConfigPath, "atlassian")
+	return kubectlOptions
 }
 
 func contains(s []string, e string) bool {

--- a/test/e2etest/installer_test.go
+++ b/test/e2etest/installer_test.go
@@ -18,6 +18,8 @@ func TestInstaller(t *testing.T) {
 
 	runInstallScript(testConfig.ConfigPath)
 
+	clusterHealthTests(t, testConfig)
+
 	if contains(productList, bamboo) {
 		bambooHealthTests(t, testConfig)
 	}

--- a/test/e2etest/test-config.tfvars.tmpl
+++ b/test/e2etest/test-config.tfvars.tmpl
@@ -29,7 +29,7 @@ resource_tags = {
 instance_types = ["m5.xlarge"]
 
 # Desired number of nodes that the node group should launch with initially.
-desired_capacity = 3
+desired_capacity = 1
 
 # Domain name base for the ingress controller. The final domain is subdomain within this domain. (eg.: environment.domain.com)
 domain = "deplops.com"

--- a/test/unittest/eks_test.go
+++ b/test/unittest/eks_test.go
@@ -77,3 +77,43 @@ func TestEksDesiredCapacityUnderLimit(t *testing.T) {
 	assert.NotNil(t, err)
 	assert.Contains(t, err.Error(), "Desired capacity must be between 1 and 10, inclusive.")
 }
+
+func TestAutoscalerHelmRelease(t *testing.T) {
+	t.Parallel()
+
+	tfOptions := GenerateTFOptions(EksWithValidValues, t, eksModule)
+
+	plan := terraform.InitAndPlanAndShowWithStruct(t, tfOptions)
+	autoscalerKey := "helm_release.cluster-autoscaler"
+
+	terraform.AssertPlannedValuesMapKeyExists(t, plan, autoscalerKey)
+	autoscaler := plan.ResourcePlannedValuesMap[autoscalerKey]
+
+	// verify Bamboo
+	assert.Equal(t, "deployed", autoscaler.AttributeValues["status"])
+	assert.Equal(t, "cluster-autoscaler", autoscaler.AttributeValues["chart"])
+	assert.Equal(t, "https://kubernetes.github.io/autoscaler", autoscaler.AttributeValues["repository"])
+
+	// verify `enable_irsa = true` creates OpenID connector for the cluster
+	terraform.AssertPlannedValuesMapKeyExists(t, plan, "module.eks.aws_iam_openid_connect_provider.oidc_provider[0]")
+
+	// verify the IAM policy is created
+	terraform.AssertPlannedValuesMapKeyExists(t, plan, "aws_iam_policy.cluster_autoscaler")
+}
+
+func TestEksNodeGroupIsOnlyInOneSubnet(t *testing.T) {
+	t.Parallel()
+
+	tfOptions := GenerateTFOptions(EksWithValidValues, t, eksModule)
+
+	plan := terraform.InitAndPlanAndShowWithStruct(t, tfOptions)
+
+	// verify that the EKS node group is only using one subnet
+	nodeGroupKey := "module.eks.module.node_groups.aws_eks_node_group.workers[\"appNodes\"]"
+
+	terraform.AssertPlannedValuesMapKeyExists(t, plan, nodeGroupKey)
+	nodeGroup := plan.ResourcePlannedValuesMap[nodeGroupKey]
+	subnets := nodeGroup.AttributeValues["subnet_ids"].([]interface{})
+
+	assert.Equal(t, 1, len(subnets))
+}

--- a/test/unittest/test_variables.go
+++ b/test/unittest/test_variables.go
@@ -38,6 +38,7 @@ var EksWithValidValues = map[string]interface{}{
 	"cluster_name": "dummy-cluster-name",
 	"vpc_id":       "dummy_vpc_id",
 	"subnets":      []string{"subnet1", "subnet2"},
+	"region":       "us-east-1",
 
 	"instance_types":   []string{"instance_type1", "instance_type2"},
 	"desired_capacity": 1,
@@ -47,6 +48,7 @@ var EksWithInvalidClusterName = map[string]interface{}{
 	"cluster_name": "cluster name with invalid spaces",
 	"vpc_id":       "dummy_vpc_id",
 	"subnets":      []string{"subnet1", "subnet2"},
+	"region":       "us-east-1",
 
 	"instance_types":   []string{"instance_type1", "instance_type2"},
 	"desired_capacity": 1,
@@ -56,6 +58,7 @@ var EksWithDesiredCapacityOverLimit = map[string]interface{}{
 	"cluster_name": "dummy-cluster-name",
 	"vpc_id":       "dummy_vpc_id",
 	"subnets":      []string{"subnet1", "subnet2"},
+	"region":       "us-east-1",
 
 	"instance_types":   []string{"instance_type1", "instance_type2"},
 	"desired_capacity": 11,
@@ -65,6 +68,7 @@ var EksDesiredCapacityUnderLimit = map[string]interface{}{
 	"cluster_name": "dummy-cluster-name",
 	"vpc_id":       "dummy_vpc_id",
 	"subnets":      []string{"subnet1", "subnet2"},
+	"region":       "us-east-1",
 
 	"instance_types":   []string{"instance_type1", "instance_type2"},
 	"desired_capacity": 0,


### PR DESCRIPTION
* add cluster-autoscaler helm release
* create IAM role with necessary permission policy to scale the EKS cluster
* use single subnet for the EKS node group
* enable IRSA (IAM Roles for Service Accounts) in the EKS cluster
* upgrade IAM module to 4.13.2
* add region variable to the EKS module
* add helm provide for EKS module
* add unit tests
* add e2e test case for autoscaler
* decrease the initial e2e capacity to 1 (and expect autoscaler to increase the number of nodes)
* fix developer docs