### PR TITLE
TFKUBE-383: Fix the synchrony installation

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -268,7 +268,7 @@ set_synchrony_url() {
   if [ -z "${DOMAIN}" ] && [ -n "${INSTALL_CONFLUENCE}" ]; then
     log "Configuring the Synchrony service."
     SYNCHRONY_FULL_URL=$(terraform output | sed "s/ //g" | grep "synchrony_url=" | sed -nE 's/^.*"(.*)".*$/\1/p')
-    helm upgrade confluence atlassian-data-center/confluence -n atlassian --reuse-values --set synchrony.ingressUrl="${SYNCHRONY_FULL_URL}" > /dev/null
+    helm upgrade confluence --repo https://atlassian.github.io/data-center-helm-charts confluence -n atlassian --reuse-values --set synchrony.ingressUrl="${SYNCHRONY_FULL_URL}" > /dev/null
     log "Synchrony URL is set to '${SYNCHRONY_FULL_URL}'."
   fi
 }
@@ -338,4 +338,3 @@ enable_ssh_tcp_protocol_on_lb_listener
 
 # Show the list of installed Helm charts
 helm list --namespace atlassian
-


### PR DESCRIPTION
This is just a temporary fix for now. After merging https://github.com/atlassian-labs/data-center-terraform/pull/186 this won't be necessary as we will setup synchrony in terraform.

Because this fix is simple and it might take some time for the ingress PR to get merged, I think we can merge this meanwhile to cover use case if customer doesn't have the helm repo installed.