### PR TITLE
TFKUBE-412: Add shared home restore

### DIFF
--- a/config.tfvars
+++ b/config.tfvars
@@ -219,6 +219,8 @@ bitbucket_db_iops                 = 1000
 #bitbucket_elasticsearch_storage  = "<REQUESTS_STORAGE>"
 #bitbucket_elasticsearch_replicas = "<NUMBER_OF_NODES>"
 
+# Dataset Restore
+
 # Database restore configuration
 # If you want to restore the database from a snapshot, uncomment the following line and provide the snapshot identifier.
 # This will restore the database from the snapshot and will not create a new database.
@@ -231,6 +233,12 @@ bitbucket_db_iops                 = 1000
 # If password is not provided, a random password will be generated.
 #bitbucket_db_master_username     = "<DB_MASTER_USERNAME>"
 #bitbucket_db_master_password     = "<DB_MASTER_PASSWORD>"
+
+# Shared home restore configuration
+# To restore shared home dataset, you can provide EBS snapshot ID that contains content of the shared home volume.
+# This volume will be mounted to the NFS server and used when the product is started.
+# Make sure the snapshot is available in the region you are deploying to and it follows all product requirements.
+#bitbucket_shared_home_snapshot_id = "<SHARED_HOME_EBS_SNAPSHOT_IDENTIFIER>"
 
 ################################################################################
 # Bamboo Settings

--- a/dc-infrastructure.tf
+++ b/dc-infrastructure.tf
@@ -191,4 +191,6 @@ module "bitbucket" {
   elasticsearch_mem      = var.bitbucket_elasticsearch_mem
   elasticsearch_storage  = var.bitbucket_elasticsearch_storage
   elasticsearch_replicas = var.bitbucket_elasticsearch_replicas
+
+  shared_home_snapshot_id = var.bitbucket_shared_home_snapshot_id
 }

--- a/modules/AWS/eks/main.tf
+++ b/modules/AWS/eks/main.tf
@@ -39,3 +39,8 @@ module "eks" {
     }
   }
 }
+
+# Exposing the single AWS subnet used by the EKS nodes - this is required for EBS volume creation for shared home PVC
+data "aws_subnet" "eks_subnet" {
+  id = one(module.eks.node_groups["appNodes"]["subnet_ids"])
+}

--- a/modules/AWS/eks/main.tf
+++ b/modules/AWS/eks/main.tf
@@ -39,8 +39,3 @@ module "eks" {
     }
   }
 }
-
-# Exposing the single AWS subnet used by the EKS nodes - this is required for EBS volume creation for shared home PVC
-data "aws_subnet" "eks_subnet" {
-  id = one(module.eks.node_groups["appNodes"]["subnet_ids"])
-}

--- a/modules/AWS/eks/outputs.tf
+++ b/modules/AWS/eks/outputs.tf
@@ -38,3 +38,7 @@ output "max_cluster_size" {
 output "min_cluster_size" {
   value = module.eks.node_groups["appNodes"]["scaling_config"][0]["min_size"]
 }
+
+output "availability_zone" {
+  value = data.aws_subnet.eks_subnet.availability_zone
+}

--- a/modules/AWS/eks/outputs.tf
+++ b/modules/AWS/eks/outputs.tf
@@ -40,5 +40,7 @@ output "min_cluster_size" {
 }
 
 output "availability_zone" {
-  value = data.aws_subnet.eks_subnet.availability_zone
+  # TODO we are assuming the used availability zone is always aws-region"a"
+  # Fetching this value dynamically from ASG subnet brings additional challenges
+  value = "${var.region}a"
 }

--- a/modules/products/bitbucket/helm.tf
+++ b/modules/products/bitbucket/helm.tf
@@ -60,6 +60,11 @@ resource "helm_release" "bitbucket" {
           persistentVolumeClaim = {
             create           = true
             storageClassName = ""
+            resources = {
+              requests = {
+                storage = var.shared_home_size
+              }
+            }
           }
         }
       }

--- a/modules/products/bitbucket/helm.tf
+++ b/modules/products/bitbucket/helm.tf
@@ -6,7 +6,7 @@ resource "helm_release" "bitbucket" {
   repository = local.helm_chart_repository
   chart      = local.product_name
   version    = local.bitbucket_helm_chart_version
-  timeout    = 10 * 60 # autoscaler potentially needs to scale up the cluster
+  timeout    = 120 * 60 # TODO - convert this to variable with default of 10 minutes
 
   values = [
     yamlencode({
@@ -61,7 +61,6 @@ resource "helm_release" "bitbucket" {
             create           = true
             storageClassName = ""
           }
-          subPath = "${local.product_name}-${random_string.random.result}"
         }
       }
     }),
@@ -80,10 +79,4 @@ data "kubernetes_service" "bitbucket" {
     name      = local.product_name
     namespace = var.namespace
   }
-}
-
-resource "random_string" "random" {
-  length  = 10
-  special = false
-  number  = true
 }

--- a/modules/products/bitbucket/helm.tf
+++ b/modules/products/bitbucket/helm.tf
@@ -60,11 +60,6 @@ resource "helm_release" "bitbucket" {
           persistentVolumeClaim = {
             create           = true
             storageClassName = ""
-            resources = {
-              requests = {
-                storage = var.shared_home_size
-              }
-            }
           }
         }
       }

--- a/modules/products/bitbucket/main.tf
+++ b/modules/products/bitbucket/main.tf
@@ -16,12 +16,13 @@ resource "aws_route53_record" "bitbucket" {
 module "nfs" {
   source = "./nfs"
 
-  namespace       = var.namespace
-  requests_cpu    = var.nfs_requests_cpu
-  requests_memory = var.nfs_requests_memory
-  limits_cpu      = var.nfs_limits_cpu
-  limits_memory   = var.nfs_limits_memory
-  capacity        = var.shared_home_size
+  namespace         = var.namespace
+  requests_cpu      = var.nfs_requests_cpu
+  requests_memory   = var.nfs_requests_memory
+  limits_cpu        = var.nfs_limits_cpu
+  limits_memory     = var.nfs_limits_memory
+  capacity          = var.shared_home_size
+  availability_zone = data.aws_subnet.eks_subnet.availability_zone
 }
 
 module "database" {
@@ -35,4 +36,12 @@ module "database" {
   iops                 = var.db_iops
   vpc                  = var.vpc
   major_engine_version = var.db_major_engine_version
+}
+
+data "aws_eks_cluster" "eks_cluster" {
+  name = var.eks.cluster_id
+}
+
+data "aws_subnet" "eks_subnet" {
+  id = data.aws_eks_cluster.eks_cluster.vpc_config[0]["subnet_ids"]
 }

--- a/modules/products/bitbucket/main.tf
+++ b/modules/products/bitbucket/main.tf
@@ -43,5 +43,5 @@ data "aws_eks_cluster" "eks_cluster" {
 }
 
 data "aws_subnet" "eks_subnet" {
-  id = data.aws_eks_cluster.eks_cluster.vpc_config[0]["subnet_ids"][0]
+  id = one(data.aws_eks_cluster.eks_cluster.vpc_config[0]["subnet_ids"])
 }

--- a/modules/products/bitbucket/main.tf
+++ b/modules/products/bitbucket/main.tf
@@ -43,5 +43,5 @@ data "aws_eks_cluster" "eks_cluster" {
 }
 
 data "aws_subnet" "eks_subnet" {
-  id = data.aws_eks_cluster.eks_cluster.vpc_config[0]["subnet_ids"]
+  id = data.aws_eks_cluster.eks_cluster.vpc_config[0]["subnet_ids"][0]
 }

--- a/modules/products/bitbucket/main.tf
+++ b/modules/products/bitbucket/main.tf
@@ -22,7 +22,7 @@ module "nfs" {
   limits_cpu        = var.nfs_limits_cpu
   limits_memory     = var.nfs_limits_memory
   capacity          = var.shared_home_size
-  availability_zone = data.aws_subnet.eks_subnet.availability_zone
+  availability_zone = var.eks.availability_zone
 }
 
 module "database" {
@@ -36,12 +36,4 @@ module "database" {
   iops                 = var.db_iops
   vpc                  = var.vpc
   major_engine_version = var.db_major_engine_version
-}
-
-data "aws_eks_cluster" "eks_cluster" {
-  name = var.eks.cluster_id
-}
-
-data "aws_subnet" "eks_subnet" {
-  id = one(data.aws_eks_cluster.eks_cluster.vpc_config[0]["subnet_ids"])
 }

--- a/modules/products/bitbucket/main.tf
+++ b/modules/products/bitbucket/main.tf
@@ -16,13 +16,14 @@ resource "aws_route53_record" "bitbucket" {
 module "nfs" {
   source = "./nfs"
 
-  namespace         = var.namespace
-  requests_cpu      = var.nfs_requests_cpu
-  requests_memory   = var.nfs_requests_memory
-  limits_cpu        = var.nfs_limits_cpu
-  limits_memory     = var.nfs_limits_memory
-  capacity          = var.shared_home_size
-  availability_zone = var.eks.availability_zone
+  namespace               = var.namespace
+  requests_cpu            = var.nfs_requests_cpu
+  requests_memory         = var.nfs_requests_memory
+  limits_cpu              = var.nfs_limits_cpu
+  limits_memory           = var.nfs_limits_memory
+  capacity                = var.shared_home_size
+  availability_zone       = var.eks.availability_zone
+  shared_home_snapshot_id = var.shared_home_snapshot_id
 }
 
 module "database" {

--- a/modules/products/bitbucket/nfs/locals.tf
+++ b/modules/products/bitbucket/nfs/locals.tf
@@ -1,0 +1,5 @@
+locals {
+  storage_class = "gp2"
+
+  product = "bitbucket" # TODO this has to be changed into variable when extracting module
+}

--- a/modules/products/bitbucket/nfs/main.tf
+++ b/modules/products/bitbucket/nfs/main.tf
@@ -1,8 +1,8 @@
 resource "aws_ebs_volume" "shared_home" {
   availability_zone = var.availability_zone
 
-  snapshot_id = var.shared_home_snapshot_id ? var.shared_home_snapshot_id : null
-  size        = var.capacity
+  snapshot_id = var.shared_home_snapshot_id != null ? var.shared_home_snapshot_id : null
+  size        = tonumber(regex("\\d+", var.capacity))
   type        = "gp2"
 
   tags = {
@@ -18,7 +18,7 @@ resource "kubernetes_persistent_volume" "shared_home" {
   spec {
     access_modes = ["ReadWriteOnce"]
     capacity = {
-      storage = "${var.capacity}G"
+      storage = var.capacity
     }
     storage_class_name = "gp2"
     persistent_volume_source {
@@ -38,7 +38,7 @@ resource "kubernetes_persistent_volume_claim" "shared_home" {
     access_modes = ["ReadWriteOnce"]
     resources {
       requests = {
-        storage = "${var.capacity}G"
+        storage = var.capacity
       }
     }
     storage_class_name = "gp2"

--- a/modules/products/bitbucket/nfs/main.tf
+++ b/modules/products/bitbucket/nfs/main.tf
@@ -13,7 +13,7 @@ resource "aws_ebs_volume" "shared_home" {
 
 resource "kubernetes_persistent_volume" "shared_home" {
   metadata {
-    name = "bitbucket-shared-home-pv"
+    name = "bitbucket-nfs-pv"
   }
   spec {
     access_modes = ["ReadWriteOnce"]
@@ -31,7 +31,7 @@ resource "kubernetes_persistent_volume" "shared_home" {
 
 resource "kubernetes_persistent_volume_claim" "shared_home" {
   metadata {
-    name      = "bitbucket-shared-home-pvc"
+    name      = "bitbucket-nfs-pvc"
     namespace = var.namespace
   }
   spec {

--- a/modules/products/bitbucket/nfs/nfs-server/.helmignore
+++ b/modules/products/bitbucket/nfs/nfs-server/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/modules/products/bitbucket/nfs/nfs-server/Chart.yaml
+++ b/modules/products/bitbucket/nfs/nfs-server/Chart.yaml
@@ -1,0 +1,7 @@
+apiVersion: v2
+name: nfs-server
+description: A NFS server used to run integration tests. Do not use in production.
+
+type: application
+version: 0.1.0
+appVersion: "2.0"

--- a/modules/products/bitbucket/nfs/nfs-server/Chart.yaml
+++ b/modules/products/bitbucket/nfs/nfs-server/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: nfs-server
-description: A NFS server used to run integration tests. Do not use in production.
+description: A NFS server for testing purposes. Do not use in production.
 
 type: application
 version: 0.1.0

--- a/modules/products/bitbucket/nfs/nfs-server/Chart.yaml
+++ b/modules/products/bitbucket/nfs/nfs-server/Chart.yaml
@@ -3,5 +3,5 @@ name: nfs-server
 description: A NFS server for testing purposes. Do not use in production.
 
 type: application
-version: 0.1.0
+version: 0.2.0
 appVersion: "2.0"

--- a/modules/products/bitbucket/nfs/nfs-server/templates/NOTES.txt
+++ b/modules/products/bitbucket/nfs/nfs-server/templates/NOTES.txt
@@ -1,0 +1,1 @@
+NFS Server installed.

--- a/modules/products/bitbucket/nfs/nfs-server/templates/_helpers.tpl
+++ b/modules/products/bitbucket/nfs/nfs-server/templates/_helpers.tpl
@@ -1,0 +1,91 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "nfs-server.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "nfs-server.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "nfs-server.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "nfs-server.labels" -}}
+helm.sh/chart: {{ include "nfs-server.chart" . }}
+{{ include "nfs-server.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "nfs-server.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "nfs-server.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "nfs-server.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "nfs-server.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}
+
+{{- define "nfs-server.volumes"}}
+{{- if .Values.persistence.volumeClaimName }}
+volumes:
+- name: data
+  persistentVolumeClaim:
+    claimName: {{ .Values.persistence.volumeClaimName }}
+{{- end}}
+{{- end}}
+
+{{- define "nfs-server.volumeClaimTemplate" -}}
+{{- if not .Values.persistence.volumeClaimName }}
+volumeClaimTemplates:
+    - metadata:
+        name: data
+        {{- with .Values.persistence.annotations }}
+        annotations:
+          {{- toYaml . | indent 10 }}
+        {{- end }}
+      spec:
+        accessModes: [ "ReadWriteOnce" ]
+        {{- if not (kindIs "invalid" .Values.persistence.storageClassName) }}
+        storageClassName: {{ .Values.persistence.storageClassName | quote }}
+        {{- end }}
+        resources:
+          requests:
+            storage: {{ .Values.persistence.size | default "1Gi" }}
+{{- end }}
+{{- end }}

--- a/modules/products/bitbucket/nfs/nfs-server/templates/service.yaml
+++ b/modules/products/bitbucket/nfs/nfs-server/templates/service.yaml
@@ -1,0 +1,62 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "nfs-server.fullname" . }}
+  labels:
+    {{- include "nfs-server.labels" . | nindent 4 }}
+spec:
+  type: {{ .Values.service.type }}
+  {{- if contains "ClusterIP" .Values.service.type }}
+  clusterIP: {{ .Values.service.clusterIP }}
+  {{- end }}
+  ports:
+    - port: {{ .Values.service.nfsPort }}
+      targetPort: nfs
+      protocol: TCP
+      name: nfs
+    - port: {{ .Values.service.nfsPort }}
+      targetPort: nfs-udp
+      protocol: UDP
+      name: nfs-udp
+    - port: {{ .Values.service.mountdPort }}
+      targetPort: mountd
+      protocol: TCP
+      name: mountd
+    - port: {{ .Values.service.mountdPort }}
+      targetPort: mountd-udp
+      protocol: UDP
+      name: mountd-udp
+    - port: {{ .Values.service.rpcbindPort }}
+      targetPort: rpcbind
+      protocol: TCP
+      name: rpcbind
+    - port: {{ .Values.service.rpcbindPort }}
+      targetPort: rpcbind-udp
+      protocol: UDP
+      name: rpcbind-udp
+    - port: {{ .Values.service.statdPort }}
+      targetPort: statd
+      protocol: TCP
+      name: statd
+    - port: {{ .Values.service.statdPort }}
+      targetPort: statd-udp
+      protocol: UDP
+      name: statd-udp
+    - port: {{ .Values.service.statdOutgoingPort }}
+      targetPort: statd-out
+      protocol: TCP
+      name: statd-out
+    - port: {{ .Values.service.statdOutgoingPort }}
+      targetPort: statd-out-udp
+      protocol: UDP
+      name: statd-out-udp
+    - port: {{ .Values.service.lockdPort }}
+      targetPort: lockd
+      protocol: TCP
+      name: lockd
+    - port: {{ .Values.service.lockdPort }}
+      targetPort: lockd-udp
+      protocol: UDP
+      name: lockd-udp
+  selector:
+    {{- include "nfs-server.selectorLabels" . | nindent 4 }}

--- a/modules/products/bitbucket/nfs/nfs-server/templates/serviceaccount.yaml
+++ b/modules/products/bitbucket/nfs/nfs-server/templates/serviceaccount.yaml
@@ -1,0 +1,12 @@
+{{- if .Values.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "nfs-server.serviceAccountName" . }}
+  labels:
+    {{- include "nfs-server.labels" . | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/modules/products/bitbucket/nfs/nfs-server/templates/statefulset.yaml
+++ b/modules/products/bitbucket/nfs/nfs-server/templates/statefulset.yaml
@@ -1,0 +1,120 @@
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: {{ include "nfs-server.fullname" . }}
+  labels:
+    {{- include "nfs-server.labels" . | nindent 4 }}
+spec:
+  replicas: {{ .Values.replicaCount }}
+  serviceName: {{ include "nfs-server.fullname" . }}
+  selector:
+    matchLabels:
+      {{- include "nfs-server.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      {{- with .Values.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      labels:
+        {{- include "nfs-server.selectorLabels" . | nindent 8 }}
+    spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      serviceAccountName: {{ include "nfs-server.serviceAccountName" . }}
+      securityContext:
+        {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      containers:
+        - name: {{ .Chart.Name }}
+          securityContext:
+            {{- toYaml .Values.securityContext | nindent 12 }}
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          env:
+            - name: MOUNTD_PORT
+              value: "{{ .Values.service.mountdPort }}"
+            - name: NFS_PORT
+              value: "{{ .Values.service.nfsPort }}"
+            - name: STATD_PORT
+              value: "{{ .Values.service.statdPort }}"
+            - name: STATD_PORT_OUT
+              value: "{{ .Values.service.statdOutgoingPort }}"
+            - name: LOCKD_PORT
+              value: "{{ .Values.service.lockdPort }}"
+            - name: EXPORT_PATH
+              value: "{{ .Values.exportPath }}"
+            {{- with .Values.podEnvironmentVariables }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
+          ports:
+          - name: nfs
+            containerPort: {{ .Values.service.nfsPort }}
+            protocol: TCP
+          - name: nfs-udp
+            containerPort: {{ .Values.service.nfsPort }}
+            protocol: UDP
+          - name: mountd
+            containerPort: {{ .Values.service.mountdPort }}
+            protocol: TCP
+          - name: mountd-udp
+            containerPort: {{ .Values.service.mountdPort }}
+            protocol: UDP
+          - name: rpcbind
+            containerPort: 111
+            protocol: TCP
+          - name: rpcbind-udp
+            containerPort: 111
+            protocol: UDP
+          - name: statd
+            containerPort: {{ .Values.service.statdPort }}
+            protocol: TCP
+          - name: statd-udp
+            containerPort: {{ .Values.service.statdPort }}
+            protocol: UDP
+          - name: statd-out
+            containerPort: {{ .Values.service.statdOutgoingPort }}
+            protocol: TCP
+          - name: statd-out-udp
+            containerPort: {{ .Values.service.statdOutgoingPort }}
+            protocol: UDP
+          - name: lockd
+            containerPort: {{ .Values.service.lockdPort }}
+            protocol: TCP
+          - name: lockd-udp
+            containerPort: {{ .Values.service.lockdPort }}
+            protocol: UDP
+          livenessProbe:
+            exec:
+              command:
+                - /usr/local/bin/docker-entrypoint.sh
+                - healthcheck
+            initialDelaySeconds: 30
+            periodSeconds: 10
+          startupProbe:
+            exec:
+              command:
+                - /usr/local/bin/docker-entrypoint.sh
+                - healthcheck
+            failureThreshold: 30
+            periodSeconds: 1
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+          volumeMounts:
+            - name: data
+              mountPath: /srv/nfs
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{ include "nfs-server.volumes" . | nindent 6 }}
+  {{ include "nfs-server.volumeClaimTemplate" . | nindent 2 }}

--- a/modules/products/bitbucket/nfs/nfs-server/values.yaml
+++ b/modules/products/bitbucket/nfs/nfs-server/values.yaml
@@ -1,0 +1,79 @@
+# Default values for nfs-server.
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.
+
+replicaCount: 1
+
+image:
+  repository: atlassian/nfs-server-test
+  pullPolicy: IfNotPresent
+  # Overrides the image tag whose default is the chart appVersion.
+  tag: ""
+
+imagePullSecrets: []
+nameOverride: ""
+fullnameOverride: ""
+
+# The path that should be exported by the NFS server
+exportPath: /srv/nfs
+
+serviceAccount:
+  # Specifies whether a service account should be created
+  create: true
+  # Annotations to add to the service account
+  annotations: {}
+  # The name of the service account to use.
+  # If not set and create is true, a name is generated using the fullname template
+  name: ""
+
+podAnnotations: {}
+
+podSecurityContext: {}
+  # fsGroup: 2000
+
+podEnvironmentVariables: []
+#  - name: DEBUG
+#    value: 'true'
+
+securityContext:
+  capabilities:
+    add:
+      - DAC_READ_SEARCH
+      - SYS_RESOURCE
+
+service:
+  # ClusterIP is required
+  type: ClusterIP
+  # If you want to run `helm test`, set this to a specific IP so the test can mount the NFS export at the correct IP
+  # clusterIP: "172.16.0.1"
+  nfsPort: 2049
+  mountdPort: 20048
+  rpcbindPort: 111
+  statdPort: 32765
+  statdOutgoingPort: 32766
+  lockdPort: 32767
+
+persistence:
+  volumeClaimName:
+  annotations: {}
+  size: 5Gi
+  # If set to non-empty string value, this will specify the storage class to be used.
+  # If left without value, the default Storage Class will be utilised.
+  # Alternatively, can be set to the empty string "", to indicate that no Storage Class should be used here.
+  storageClassName:
+
+
+
+resources:
+  # limits:
+  #   cpu: 100m
+  #   memory: 128Mi
+  requests:
+    cpu: 500m
+    memory: 256Mi
+
+nodeSelector: {}
+
+tolerations: []
+
+affinity: {}

--- a/modules/products/bitbucket/nfs/variables.tf
+++ b/modules/products/bitbucket/nfs/variables.tf
@@ -18,13 +18,13 @@ variable "capacity" {
 variable "requests_cpu" {
   description = "The minimum CPU compute to request for the NFS instance"
   type        = string
-  default     = "0.25"
+  default     = "1"
 }
 
 variable "requests_memory" {
   description = "The minimum amount of memory to allocate to the NFS instance"
   type        = string
-  default     = "256Mi"
+  default     = "1Gi"
 }
 
 variable "limits_cpu" {
@@ -36,7 +36,7 @@ variable "limits_cpu" {
 variable "limits_memory" {
   description = "The maximum amount of memory to allocate to the NFS instance"
   type        = string
-  default     = "1Gi"
+  default     = "2Gi"
 }
 
 variable "availability_zone" {
@@ -45,11 +45,11 @@ variable "availability_zone" {
 }
 
 variable "shared_home_snapshot_id" {
-  description = "EBS Snapshot ID with shared home content."
+  description = "EBS Snapshot ID with content of the product's shared home."
   type        = string
   default     = null
   validation {
-    condition     = var.shared_home_snapshot_id == null || can(regex("^.{1,255}$", var.shared_home_snapshot_id))
+    condition     = var.shared_home_snapshot_id == null || can(regex("^snap-\\w{17}$", var.shared_home_snapshot_id))
     error_message = "Provide correct EBS snapshot ID."
   }
 }

--- a/modules/products/bitbucket/nfs/variables.tf
+++ b/modules/products/bitbucket/nfs/variables.tf
@@ -30,11 +30,26 @@ variable "requests_memory" {
 variable "limits_cpu" {
   description = "The maximum CPU compute to allocate to the NFS instance"
   type        = string
-  default     = "0.25"
+  default     = "2"
 }
 
 variable "limits_memory" {
   description = "The maximum amount of memory to allocate to the NFS instance"
   type        = string
-  default     = "256Mi"
+  default     = "1Gi"
+}
+
+variable "availability_zone" {
+  description = "Availability zone for the EBS volume to be created in."
+  type        = string
+}
+
+variable "shared_home_snapshot_id" {
+  description = "EBS Snapshot ID with shared home content."
+  type        = string
+  default     = null
+  validation {
+    condition     = var.shared_home_snapshot_id == null || can(regex("^.{1,255}$", var.shared_home_snapshot_id))
+    error_message = "Provide correct EBS snapshot ID."
+  }
 }

--- a/modules/products/bitbucket/variables.tf
+++ b/modules/products/bitbucket/variables.tf
@@ -154,3 +154,13 @@ variable "display_name" {
     error_message = "Bitbucket display name must be a non-empty value less than 255 characters."
   }
 }
+
+variable "shared_home_snapshot_id" {
+  description = "EBS Snapshot ID with shared home content."
+  type        = string
+  default     = null
+  validation {
+    condition     = var.shared_home_snapshot_id == null || can(regex("^.{1,255}$", var.shared_home_snapshot_id))
+    error_message = "Provide correct EBS snapshot ID."
+  }
+}

--- a/modules/products/bitbucket/variables.tf
+++ b/modules/products/bitbucket/variables.tf
@@ -179,7 +179,7 @@ variable "shared_home_snapshot_id" {
   type        = string
   default     = null
   validation {
-    condition     = var.shared_home_snapshot_id == null || can(regex("^.{1,255}$", var.shared_home_snapshot_id))
+    condition     = var.shared_home_snapshot_id == null || can(regex("^snap-\\w{17}$", var.shared_home_snapshot_id))
     error_message = "Provide correct EBS snapshot ID."
   }
 }

--- a/test/e2etest/bitbucket_test.go
+++ b/test/e2etest/bitbucket_test.go
@@ -41,7 +41,7 @@ func assertBitbucketNfsConnectivity(t *testing.T, testConfig TestConfig) {
 	returnCode, kubectlError := k8s.RunKubectlAndGetOutputE(t, kubectlOptions,
 		"exec", "bitbucket-nfs-server-0",
 		"--", "/bin/bash",
-		"-c", "echo \"Greetings from an NFS\" >> $(find /srv/nfs/bitbucket-* | head -1)/nfs-file-share-test.txt; echo $?")
+		"-c", "echo \"Greetings from an NFS\" >> $(find /srv/nfs/ | head -1)/nfs-file-share-test.txt; echo $?")
 
 	assert.Nil(t, kubectlError)
 	assert.Equal(t, "0", returnCode)

--- a/test/unittest/bitbucket_test.go
+++ b/test/unittest/bitbucket_test.go
@@ -112,6 +112,7 @@ var BitbucketCorrectVariables = map[string]interface{}{
 		},
 		"cluster_security_group": "dummy-sg",
 		"cluster_size":           2,
+		"availability_zone":      "dummy-az",
 	},
 	"vpc":                     VpcDefaultModuleVariable,
 	"db_major_engine_version": "13",
@@ -124,7 +125,7 @@ var BitbucketCorrectVariables = map[string]interface{}{
 		"admin_display_name":  "dummy_admin_display_name",
 		"admin_email_address": "dummy_admin_email_address",
 	},
-	"display_name":  "dummy_display_name",
+	"display_name": "dummy_display_name",
 	"ingress": map[string]interface{}{
 		"outputs": map[string]interface{}{
 			"r53_zone":        "dummy_r53_zone",

--- a/test/unittest/bitbucket_test.go
+++ b/test/unittest/bitbucket_test.go
@@ -90,8 +90,8 @@ func TestNfsVariablesPopulatedWithValidValues(t *testing.T) {
 	helmRelease := plan.ResourcePlannedValuesMap["helm_release.nfs"]
 	values := helmRelease.AttributeValues["values"].([]interface{})[0].(string)
 
-	expectedHelmValues := fmt.Sprintf("\"nameOverride\": \"%s\"\n\"persistence\":\n  \"size\": \"%s\"\n\"resources\":\n  \"limits\":\n    \"cpu\": \"%s\"\n    \"memory\": \"%s\"\n  \"requests\":\n    \"cpu\": \"%s\"\n    \"memory\": \"%s\"\n",
-		nfsVarChartNameOverride, nfsVarCapacity, nfsLimitsCpu, nfsLimitsMemory, nfsRequestsCpu, nfsRequestsMemory)
+	expectedHelmValues := fmt.Sprintf("\"nameOverride\": \"%s\"\n\"persistence\":\n  \"volumeClaimName\": \"%s\"\n\"resources\":\n  \"limits\":\n    \"cpu\": \"%s\"\n    \"memory\": \"%s\"\n  \"requests\":\n    \"cpu\": \"%s\"\n    \"memory\": \"%s\"\n",
+		nfsVarChartNameOverride, nfsPvc, nfsLimitsCpu, nfsLimitsMemory, nfsRequestsCpu, nfsRequestsMemory)
 
 	expectedNamespace := nfsVarNamespace
 

--- a/test/unittest/test_variables.go
+++ b/test/unittest/test_variables.go
@@ -137,15 +137,17 @@ const nfsRequestsCpu = "0.25"
 const nfsRequestsMemory = "256Mi"
 const nfsLimitsCpu = "0.25"
 const nfsLimitsMemory = "256Mi"
+const nfsPvc = "bitbucket-nfs-pvc"
 
 var NfsValidVariable = map[string]interface{}{
-	"namespace":       nfsVarNamespace,
-	"chart_name":      nfsVarChartNameOverride,
-	"capacity":        nfsVarCapacity,
-	"requests_cpu":    nfsRequestsCpu,
-	"requests_memory": nfsRequestsMemory,
-	"limits_cpu":      nfsLimitsCpu,
-	"limits_memory":   nfsLimitsMemory,
+	"namespace":         nfsVarNamespace,
+	"chart_name":        nfsVarChartNameOverride,
+	"capacity":          nfsVarCapacity,
+	"requests_cpu":      nfsRequestsCpu,
+	"requests_memory":   nfsRequestsMemory,
+	"limits_cpu":        nfsLimitsCpu,
+	"limits_memory":     nfsLimitsMemory,
+	"availability_zone": "dummy-az",
 }
 
 // DB

--- a/variables.tf
+++ b/variables.tf
@@ -520,7 +520,7 @@ variable "bitbucket_shared_home_snapshot_id" {
   type        = string
   default     = null
   validation {
-    condition     = var.bitbucket_shared_home_snapshot_id == null || can(regex("^.{1,255}$", var.bitbucket_shared_home_snapshot_id))
+    condition     = var.bitbucket_shared_home_snapshot_id == null || can(regex("^snap-\\w{17}$", var.bitbucket_shared_home_snapshot_id))
     error_message = "Provide correct EBS snapshot ID."
   }
 }

--- a/variables.tf
+++ b/variables.tf
@@ -483,6 +483,15 @@ variable "bitbucket_elasticsearch_replicas" {
   type        = number
   default     = 2
 }
+variable "bitbucket_shared_home_snapshot_id" {
+  description = "EBS Snapshot ID with shared home content."
+  type        = string
+  default     = null
+  validation {
+    condition     = var.bitbucket_shared_home_snapshot_id == null || can(regex("^.{1,255}$", var.bitbucket_shared_home_snapshot_id))
+    error_message = "Provide correct EBS snapshot ID."
+  }
+}
 
 ################################################################################
 # Bamboo Variables


### PR DESCRIPTION
## Pull request description

* Moved the NFS helm chart to the Terraform project for flexibility reasons
* Add Bitbucket snapshot ID variable (defaults to `null`)
* Expanded the NFS helm chart to include an option to define custom volume claim
* EKS module now returns the single availability zone that is used for the EKS EC2 nodes
* Bitbucket module now explicitly creates the EBS volume (from snapshot if provided), creates PV from it and then PVC that is mounted into NFS server as a shared home
* Dropped `subpath` for the Bitbucket Server helm chart shared home value
* Fixed the E2E test that is verifying a file being written to shared home
* Increased Bitbucket timeout (this should be converted to a variable)
* Increased the default NFS server resources

## Todo
- [x] fix unit tests
- [x] add variable to `config.tfvars`

## Checklist
- [x] I have successful end to end tests run (with & without domain)
- [ ] I have added unit tests (if applicable)
- [ ] I have user documentation (if applicable)
