### PR TITLE
Add DB_NAME to config file

### DIFF
--- a/config.tfvars
+++ b/config.tfvars
@@ -76,6 +76,8 @@ jira_db_major_engine_version = "12"
 jira_db_instance_class       = "db.t3.micro"
 jira_db_allocated_storage    = 100
 jira_db_iops                 = 1000
+# IF you want to restore the database from a snapshot, please provide the default db name for the snapshot. If the snapshot does not have default db name comment out this variable.
+jira_db_name = "jira"
 
 # Database restore configuration
 # If you want to restore the database from a snapshot, uncomment the following line and provide the snapshot identifier.
@@ -132,6 +134,8 @@ confluence_db_major_engine_version = "11"
 confluence_db_instance_class       = "db.t3.micro"
 confluence_db_allocated_storage    = 100
 confluence_db_iops                 = 1000
+# IF you want to restore the database from a snapshot, please provide the default db name for the snapshot. If the snapshot does not have default db name comment out this variable.
+confluence_db_name = "confluence"
 
 # Database restore configuration
 # If you want to restore the database from a snapshot, uncomment the following lines and provide the snapshot identifier.
@@ -206,6 +210,8 @@ bitbucket_db_major_engine_version = "13"
 bitbucket_db_instance_class       = "db.t3.micro"
 bitbucket_db_allocated_storage    = 100
 bitbucket_db_iops                 = 1000
+# IF you want to restore the database from a snapshot, please provide the default db name for the snapshot. If the snapshot does not have default db name comment out this variable.
+bitbucket_db_name = "bitbucket"
 
 # Bitbucket NFS instance resource configuration
 #bitbucket_nfs_requests_cpu    = "<REQUESTS_CPU>"
@@ -304,6 +310,7 @@ bamboo_db_major_engine_version = "13"
 bamboo_db_instance_class       = "db.t3.micro"
 bamboo_db_allocated_storage    = 100
 bamboo_db_iops                 = 1000
+bamboo_db_name                 = "bamboo"
 
 # (Optional) URL for dataset to import
 # The provided default is the dataset used in the DCAPT framework.

--- a/config.tfvars
+++ b/config.tfvars
@@ -76,7 +76,7 @@ jira_db_major_engine_version = "12"
 jira_db_instance_class       = "db.t3.micro"
 jira_db_allocated_storage    = 100
 jira_db_iops                 = 1000
-# IF you want to restore the database from a snapshot, please provide the default db name for the snapshot. If the snapshot does not have default db name comment out this variable.
+# If you restore the database, you need to provide the db name from the snapshot. If the snapshot does not have default db name comment out this variable.
 jira_db_name = "jira"
 
 # Database restore configuration
@@ -134,7 +134,7 @@ confluence_db_major_engine_version = "11"
 confluence_db_instance_class       = "db.t3.micro"
 confluence_db_allocated_storage    = 100
 confluence_db_iops                 = 1000
-# IF you want to restore the database from a snapshot, please provide the default db name for the snapshot. If the snapshot does not have default db name comment out this variable.
+# If you restore the database, you need to provide the db name from the snapshot. If the snapshot does not have default db name comment out this variable.
 confluence_db_name = "confluence"
 
 # Database restore configuration
@@ -210,7 +210,7 @@ bitbucket_db_major_engine_version = "13"
 bitbucket_db_instance_class       = "db.t3.micro"
 bitbucket_db_allocated_storage    = 100
 bitbucket_db_iops                 = 1000
-# IF you want to restore the database from a snapshot, please provide the default db name for the snapshot. If the snapshot does not have default db name comment out this variable.
+# If you restore the database, you need to provide the db name from the snapshot. If the snapshot does not have default db name comment out this variable.
 bitbucket_db_name = "bitbucket"
 
 # Bitbucket NFS instance resource configuration

--- a/dc-infrastructure.tf
+++ b/dc-infrastructure.tf
@@ -40,6 +40,7 @@ module "bamboo" {
     db_allocated_storage = var.bamboo_db_allocated_storage
     db_instance_class    = var.bamboo_db_instance_class
     db_iops              = var.bamboo_db_iops
+    db_name              = var.bamboo_db_name
   }
 
   bamboo_configuration = {
@@ -83,6 +84,7 @@ module "jira" {
   db_allocated_storage    = var.jira_db_allocated_storage
   db_instance_class       = var.jira_db_instance_class
   db_iops                 = var.jira_db_iops
+  db_name                 = var.jira_db_name
   db_snapshot_identifier  = var.jira_db_snapshot_identifier
   db_master_username      = var.jira_db_master_username
   db_master_password      = var.jira_db_master_password
@@ -123,6 +125,7 @@ module "confluence" {
     db_allocated_storage = var.confluence_db_allocated_storage
     db_instance_class    = var.confluence_db_instance_class
     db_iops              = var.confluence_db_iops
+    db_name              = var.confluence_db_name
   }
 
   db_snapshot_identifier   = var.confluence_db_snapshot_identifier
@@ -163,6 +166,7 @@ module "bitbucket" {
   db_allocated_storage    = var.bitbucket_db_allocated_storage
   db_instance_class       = var.bitbucket_db_instance_class
   db_iops                 = var.bitbucket_db_iops
+  db_name                 = var.bitbucket_db_name
   db_snapshot_identifier  = var.bitbucket_db_snapshot_identifier
   db_master_username      = var.bitbucket_db_master_username
   db_master_password      = var.bitbucket_db_master_password

--- a/modules/AWS/rds/locals.tf
+++ b/modules/AWS/rds/locals.tf
@@ -1,6 +1,4 @@
 locals {
-  db_name = var.snapshot_identifier == null ? var.product : null
-
   db_master_username = var.db_master_username == null ? "postgres" : var.db_master_username
   db_master_password = var.db_master_password == null ? random_password.password.result : var.db_master_password
   db_jdbc_connection = "jdbc:postgresql://${module.db.db_instance_endpoint}/${var.product}"

--- a/modules/AWS/rds/main.tf
+++ b/modules/AWS/rds/main.tf
@@ -40,7 +40,7 @@ module "db" {
   allocated_storage = var.allocated_storage
   iops              = var.iops
 
-  name     = local.db_name
+  name     = var.db_name
   username = local.db_master_username
   password = local.db_master_password
   port     = 5432

--- a/modules/AWS/rds/variables.tf
+++ b/modules/AWS/rds/variables.tf
@@ -27,6 +27,16 @@ variable "iops" {
   type        = number
 }
 
+variable "db_name" {
+  description = "The default DB name of the DB instance."
+  validation {
+    condition     = var.db_name == null || can(regex("^[a-zA-Z_][a-zA-Z0-9_]*$", var.db_name))
+    error_message = "Invalid RDS DB name."
+  }
+  default = null
+  type = string
+}
+
 variable "eks" {
   description = "EKS module that hosts the product."
   type        = any

--- a/modules/products/bamboo/main.tf
+++ b/modules/products/bamboo/main.tf
@@ -25,5 +25,4 @@ module "database" {
   iops                    = var.db_configuration["db_iops"]
   vpc                     = var.vpc
   db_name                 = var.db_configuration["db_name"]
-
 }

--- a/modules/products/bamboo/main.tf
+++ b/modules/products/bamboo/main.tf
@@ -24,4 +24,6 @@ module "database" {
   instance_class          = var.db_configuration["db_instance_class"]
   iops                    = var.db_configuration["db_iops"]
   vpc                     = var.vpc
+  db_name                 = var.db_configuration["db_name"]
+
 }

--- a/modules/products/bamboo/variables.tf
+++ b/modules/products/bamboo/variables.tf
@@ -89,8 +89,8 @@ variable "db_configuration" {
   description = "Bamboo database spec"
   type        = map(any)
   validation {
-    condition = (length(var.db_configuration) == 3 &&
-    alltrue([for o in keys(var.db_configuration) : contains(["db_allocated_storage", "db_instance_class", "db_iops"], o)]))
+    condition = (length(var.db_configuration) == 4 &&
+    alltrue([for o in keys(var.db_configuration) : contains(["db_allocated_storage", "db_instance_class", "db_iops", "db_name"], o)]))
     error_message = "Bamboo database configuration is not valid."
   }
 }

--- a/modules/products/bitbucket/main.tf
+++ b/modules/products/bitbucket/main.tf
@@ -41,4 +41,6 @@ module "database" {
   snapshot_identifier     = var.db_snapshot_identifier
   db_master_username      = var.db_master_username
   db_master_password      = var.db_master_password
+  db_name                 = var.db_name
+
 }

--- a/modules/products/bitbucket/variables.tf
+++ b/modules/products/bitbucket/variables.tf
@@ -47,6 +47,11 @@ variable "db_iops" {
   type        = number
 }
 
+variable "db_name" {
+  description = "The default DB name of the DB instance."
+  type        = string
+}
+
 variable "replica_count" {
   description = "Number of Bitbucket application nodes"
   type        = number

--- a/modules/products/confluence/main.tf
+++ b/modules/products/confluence/main.tf
@@ -27,4 +27,6 @@ module "database" {
   snapshot_identifier     = var.db_snapshot_identifier
   db_master_username      = var.db_master_username
   db_master_password      = var.db_master_password
+  db_name                 = var.db_configuration["db_name"]
+
 }

--- a/modules/products/confluence/variables.tf
+++ b/modules/products/confluence/variables.tf
@@ -36,10 +36,10 @@ variable "db_configuration" {
   description = "Confluence database spec"
   type        = map(any)
   validation {
-    condition = (length(var.db_configuration) == 3 &&
+    condition = (length(var.db_configuration) == 4 &&
       alltrue([
         for o in keys(var.db_configuration) : contains([
-          "db_allocated_storage", "db_instance_class", "db_iops"
+          "db_allocated_storage", "db_instance_class", "db_iops", "db_name"
         ], o)
     ]))
     error_message = "Confluence database configuration is not valid."

--- a/modules/products/jira/main.tf
+++ b/modules/products/jira/main.tf
@@ -27,4 +27,5 @@ module "database" {
   snapshot_identifier     = var.db_snapshot_identifier
   db_master_username      = var.db_master_username
   db_master_password      = var.db_master_password
+  db_name                 = var.db_name
 }

--- a/modules/products/jira/variables.tf
+++ b/modules/products/jira/variables.tf
@@ -47,6 +47,11 @@ variable "db_iops" {
   type        = number
 }
 
+variable "db_name" {
+  description = "The default DB name of the DB instance."
+  type        = string
+}
+
 variable "replica_count" {
   description = "Number of Jira application nodes"
   type        = number

--- a/test/unittest/bamboo_test.go
+++ b/test/unittest/bamboo_test.go
@@ -67,6 +67,7 @@ var BambooCorrectVariables = map[string]interface{}{
 		"db_allocated_storage": 5,
 		"db_instance_class":    "dummy_db_instance_class",
 		"db_iops":              1000,
+		"db_name":              "bamboo",
 	},
 	"license":             "dummy_license",
 	"admin_username":      "dummy_admin_username",

--- a/test/unittest/bitbucket_test.go
+++ b/test/unittest/bitbucket_test.go
@@ -84,6 +84,7 @@ var BitbucketCorrectVariables = map[string]interface{}{
 	"db_allocated_storage":    5,
 	"db_instance_class":       "dummy_db_instance_class",
 	"db_iops":                 1000,
+	"db_name":                 "bitbucket",
 	"admin_configuration": map[string]interface{}{
 		"admin_username":      "dummy_admin_username",
 		"admin_password":      "dummy_admin_password",

--- a/test/unittest/confluence_test.go
+++ b/test/unittest/confluence_test.go
@@ -1,8 +1,9 @@
 package unittest
 
 import (
-	"github.com/stretchr/testify/assert"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 
 	"github.com/gruntwork-io/terratest/modules/terraform"
 )
@@ -94,6 +95,7 @@ var ConfluenceCorrectVariables = map[string]interface{}{
 		"db_allocated_storage": 5,
 		"db_instance_class":    "dummy_db_instance_class",
 		"db_iops":              1000,
+		"db_name":              "confluence",
 	},
 	"replica_count": 1,
 	"confluence_configuration": map[string]interface{}{

--- a/test/unittest/database_test.go
+++ b/test/unittest/database_test.go
@@ -61,7 +61,7 @@ func TestDbVariablesPopulatedWithValidValues(t *testing.T) {
 	assert.Equal(t, inputRdsSnapshotId, planDbSnapshotIdentifier)
 	assert.Equal(t, "postgres", planUserName)
 	assert.Equal(t, "postgres", planEngine)
-	assert.Equal(t, nil, planDbName) // This should be nil because RDS Snapshot identifier is provided
+	assert.Equal(t, dbName, planDbName) // This should be nil because RDS Snapshot identifier is provided
 	assert.Equal(t, inputInstanceClass, planInstanceClass)
 	assert.EqualValues(t, inputAllocatedStorage, planAllocatedStorage)
 	assert.EqualValues(t, inputIops, planIops)

--- a/test/unittest/jira_test.go
+++ b/test/unittest/jira_test.go
@@ -41,6 +41,7 @@ var JiraCorrectVariables = map[string]interface{}{
 	"db_allocated_storage":    5,
 	"db_instance_class":       "dummy_db_instance_class",
 	"db_iops":                 1000,
+	"db_name":                 "jira",
 	"ingress": map[string]interface{}{
 		"outputs": map[string]interface{}{
 			"r53_zone":        "dummy_r53_zone",

--- a/test/unittest/test_variables.go
+++ b/test/unittest/test_variables.go
@@ -166,6 +166,7 @@ const inputIops = 1000
 const dbVersion = 13
 const masterPwd = "dummyPassword!"
 const invalidInputRdsInstanceId = "1-"
+const dbName = "duumy_name"
 
 var DbValidVariable = map[string]interface{}{
 	"product":                 inputProduct,
@@ -173,6 +174,7 @@ var DbValidVariable = map[string]interface{}{
 	"instance_class":          inputInstanceClass,
 	"allocated_storage":       inputAllocatedStorage,
 	"iops":                    inputIops,
+	"db_name":                 dbName,
 	"eks": map[string]interface{}{
 		"kubernetes_provider_config": map[string]interface{}{
 			"host":                   "dummy-host",
@@ -194,6 +196,7 @@ var DbVariableWithDBMasterPassword = map[string]interface{}{
 	"instance_class":          inputInstanceClass,
 	"allocated_storage":       inputAllocatedStorage,
 	"iops":                    inputIops,
+	"db_name":                 dbName,
 	"eks": map[string]interface{}{
 		"kubernetes_provider_config": map[string]interface{}{
 			"host":                   "dummy-host",
@@ -216,6 +219,7 @@ var DbInvalidVariable = map[string]interface{}{
 	"instance_class":          inputInstanceClass,
 	"allocated_storage":       inputAllocatedStorage,
 	"iops":                    inputIops,
+	"db_name":                 dbName,
 	"eks": map[string]interface{}{
 		"kubernetes_provider_config": map[string]interface{}{
 			"host":                   "dummy-host",
@@ -270,6 +274,8 @@ var BitbucketInvalidVariables = map[string]interface{}{
 	"db_allocated_storage":    5,
 	"db_instance_class":       "dummy_db_instance_class",
 	"db_iops":                 1000,
+	"db_name":                 "dummy_db_name",
+
 	"admin_configuration": map[string]interface{}{
 		"invalid":             "dummy_admin_username",
 		"admin_password":      "dummy_admin_password",
@@ -329,6 +335,7 @@ var ConfluenceInvalidVariables = map[string]interface{}{
 		"db_allocated_storage": 5,
 		"db_instance_class":    "dummy_db_instance_class",
 		"db_iops":              1000,
+		"db_name":              "dummy_db_name",
 		"invalid_db_config":    "extra",
 	},
 	"replica_count": 1,

--- a/variables.tf
+++ b/variables.tf
@@ -187,6 +187,12 @@ variable "jira_db_iops" {
   type        = number
 }
 
+variable "jira_db_name" {
+  description = "The default DB name of the DB instance."
+  default     = null
+  type        = string
+}
+
 variable "jira_db_snapshot_identifier" {
   description = "The identifier for the DB snapshot to restore from. The snapshot should be in the same AWS region as the DB instance."
   default     = null
@@ -314,6 +320,12 @@ variable "confluence_db_iops" {
   type        = number
 }
 
+variable "confluence_db_name" {
+  description = "The default DB name of the DB instance."
+  default     = null
+  type        = string
+}
+
 variable "confluence_collaborative_editing_enabled" {
   description = "If true, Collaborative editing service will be enabled."
   type        = bool
@@ -424,6 +436,12 @@ variable "bitbucket_db_iops" {
   description = "The requested number of I/O operations per second that the DB instance can support."
   default     = 1000
   type        = number
+}
+
+variable "bitbucket_db_name" {
+  description = "The default DB name of the DB instance."
+  default     = null
+  type        = string
 }
 
 variable "bitbucket_display_name" {
@@ -691,6 +709,12 @@ variable "bamboo_db_iops" {
   description = "The requested number of I/O operations per second that the DB instance can support."
   default     = 1000
   type        = number
+}
+
+variable "bamboo_db_name" {
+  description = "The default DB name of the DB instance."
+  default     = null
+  type        = string
 }
 
 variable "bamboo_dataset_url" {


### PR DESCRIPTION
## Pull request description

Previously we implemented the logic to dynamically decide db_name for RDS depending on whether db_snapshot_identifier was used or not. This is because of inconsistency between snapshot provided by dc-apt team and snapshot taken by the data-center-terraform. 
This change will allow users to use input whichever db_name matching with their RDS snapshot
## Checklist
- [ ] I have successful end to end tests run (with & without domain)
- [x] I have added unit tests (if applicable)
- [x] I have user documentation (if applicable)
