### PR TITLE
TFKUBE-441: Compromise tagging failure in installer during e2e tests.

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -211,7 +211,7 @@ add_tags_to_asg_resources() {
   terraform -chdir="${TAG_MODULE_PATH}" init -no-color > "${LOG_TAGGING}"
   terraform -chdir="${TAG_MODULE_PATH}" apply -auto-approve -no-color "${OVERRIDE_CONFIG_FILE}" >> "${LOG_TAGGING}"
   if [ $? == 0 ]; then
-    log "Resource tags are applied to ASG and all EC2 instances."
+    log "Resource tags were applied to ASG and all EC2 instances."
   else
     log "Resource tags are not applied to ASG and all EC2 instances." "ERROR"
   fi

--- a/install.sh
+++ b/install.sh
@@ -201,12 +201,21 @@ create_update_infrastructure() {
 
 # Apply the tags into ASG and EC2 instances created by ASG
 add_tags_to_asg_resources() {
+  if [ -n "${FORCE_FLAG}" ]; then
+    log "The script is executed by end2end test. Tagging of ASG and EC2 resources failure will be compromised."
+    set +e
+  fi
   log "Tagging Auto Scaling Group and EC2 instances. It may take a few minutes. Please wait..."
   TAG_MODULE_PATH="${ROOT_PATH}/modules/AWS/asg_ec2_tagging"
 
   terraform -chdir="${TAG_MODULE_PATH}" init -no-color > "${LOG_TAGGING}"
   terraform -chdir="${TAG_MODULE_PATH}" apply -auto-approve -no-color "${OVERRIDE_CONFIG_FILE}" >> "${LOG_TAGGING}"
-  log "Resource tags are applied to ASG and all EC2 instances."
+  if [ $_ == 0 ]; then
+    log "Resource tags are applied to ASG and all EC2 instances."
+  else
+    log "Resource tags are not applied to ASG and all EC2 instances." "ERROR"
+  fi
+  set -e
 }
 
 set_current_context_k8s() {

--- a/install.sh
+++ b/install.sh
@@ -202,7 +202,7 @@ create_update_infrastructure() {
 # Apply the tags into ASG and EC2 instances created by ASG
 add_tags_to_asg_resources() {
   if [ -n "${FORCE_FLAG}" ]; then
-    log "The script is executed by end2end test. Tagging of ASG and EC2 resources failure will be compromised."
+    log "The script is executed by end2end test. Failure in tagging of ASG and EC2 resources will not cause the script to error out."
     set +e
   fi
   log "Tagging Auto Scaling Group and EC2 instances. It may take a few minutes. Please wait..."
@@ -213,7 +213,7 @@ add_tags_to_asg_resources() {
   if [ $? == 0 ]; then
     log "Resource tags were applied to ASG and all EC2 instances."
   else
-    log "Resource tags are not applied to ASG and all EC2 instances." "ERROR"
+    log "Resource tags were not applied to ASG and all EC2 instances." "ERROR"
   fi
   set -e
 }

--- a/install.sh
+++ b/install.sh
@@ -210,7 +210,7 @@ add_tags_to_asg_resources() {
 
   terraform -chdir="${TAG_MODULE_PATH}" init -no-color > "${LOG_TAGGING}"
   terraform -chdir="${TAG_MODULE_PATH}" apply -auto-approve -no-color "${OVERRIDE_CONFIG_FILE}" >> "${LOG_TAGGING}"
-  if [ $_ == 0 ]; then
+  if [ $? == 0 ]; then
     log "Resource tags are applied to ASG and all EC2 instances."
   else
     log "Resource tags are not applied to ASG and all EC2 instances." "ERROR"


### PR DESCRIPTION
## Pull request description

Compromise tagging failure in installer during e2e tests. We observed a case of failure caused by tagging module in e2e tests. As this is not reported not in our local tests and nor from other users and testers including out blitz, and considering tagging is not essential for e2e tests because the instances are short-living, so we can compromise it in specifically e2e test. 

## Checklist
- [x] I have successful end to end tests run (with & without domain)
- [x] I have added unit tests (if applicable)
- [x] I have user documentation (if applicable)
