### PR TITLE
TFKUBE-419: Expose timeout for helm chart installation

### DIFF
--- a/config.tfvars
+++ b/config.tfvars
@@ -53,6 +53,11 @@ jira_helm_chart_version = "1.2.0"
 # installed and configured.
 jira_replica_count = 1
 
+# Installation timeout
+# Different variables can influence how long it takes the application from installation to ready state. These
+# can be dataset restoration, resource requirements, number of replicas and others.
+#jira_installation_timeout = <MINUTES>
+
 # By default, Jira Software will use the version defined in the Helm chart. If you wish to override the version, uncomment
 # the following line and set the jira_version_tag to any of the versions available on https://hub.docker.com/r/atlassian/jira-software/tags
 #jira_version_tag = "<JIRA_VERSION_TAG>"
@@ -127,6 +132,11 @@ confluence_helm_chart_version = "1.2.0"
 # installed and configured.
 confluence_replica_count = 1
 
+# Installation timeout
+# Different variables can influence how long it takes the application from installation to ready state. These
+# can be dataset restoration, resource requirements, number of replicas and others.
+#confluence_installation_timeout = <MINUTES>
+
 # By default, Confluence will use the version defined in the Helm chart. If you wish to override the version, uncomment
 # the following line and set the confluence_version_tag to any of the versions available on https://hub.docker.com/r/atlassian/confluence/tags
 #confluence_version_tag = "<CONFLUENCE_VERSION_TAG>"
@@ -199,6 +209,11 @@ bitbucket_helm_chart_version = "1.2.0"
 
 # Number of Bitbucket application nodes
 bitbucket_replica_count = 1
+
+# Installation timeout
+# Different variables can influence how long it takes the application from installation to ready state. These
+# can be dataset restoration, resource requirements, number of replicas and others.
+#bitbucket_installation_timeout = <MINUTES>
 
 # By default, Bitbucket will use the version defined in the Bitbucket Helm chart:
 # https://github.com/atlassian/data-center-helm-charts/blob/main/src/main/charts/bitbucket/Chart.yaml 
@@ -319,6 +334,11 @@ bamboo_agent_helm_chart_version = "1.2.0"
 #bamboo_admin_password      = "<PASSWORD>"
 #bamboo_admin_display_name  = "<DISPLAY_NAME>"
 #bamboo_admin_email_address = "<EMAIL_ADDRESS>"
+
+# Installation timeout
+# Different variables can influence how long it takes the application from installation to ready state. These
+# can be dataset restoration, resource requirements, number of replicas and others.
+#bamboo_installation_timeout = <MINUTES>
 
 # Bamboo instance resource configuration
 bamboo_cpu      = "1"

--- a/dc-infrastructure.tf
+++ b/dc-infrastructure.tf
@@ -40,6 +40,8 @@ module "bamboo" {
     db_name              = var.bamboo_db_name
   }
 
+  installation_timeout = var.bamboo_installation_timeout
+
   bamboo_configuration = {
     helm_version = var.bamboo_helm_chart_version
     cpu          = var.bamboo_cpu
@@ -64,7 +66,6 @@ module "bamboo" {
   nfs_requests_memory = var.bamboo_nfs_requests_memory
   nfs_limits_cpu      = var.bamboo_nfs_limits_cpu
   nfs_limits_memory   = var.bamboo_nfs_limits_memory
-
 
   version_tag       = var.bamboo_version_tag
   agent_version_tag = var.bamboo_agent_version_tag
@@ -93,7 +94,8 @@ module "jira" {
   db_master_username      = var.jira_db_master_username
   db_master_password      = var.jira_db_master_password
 
-  replica_count = var.jira_replica_count
+  replica_count        = var.jira_replica_count
+  installation_timeout = var.jira_installation_timeout
 
   jira_configuration = {
     helm_version        = var.jira_helm_chart_version
@@ -142,9 +144,10 @@ module "confluence" {
   db_master_username       = var.confluence_db_master_username
   db_master_password       = var.confluence_db_master_password
 
-  replica_count    = var.confluence_replica_count
-  version_tag      = var.confluence_version_tag
-  enable_synchrony = var.confluence_collaborative_editing_enabled
+  replica_count        = var.confluence_replica_count
+  installation_timeout = var.confluence_installation_timeout
+  version_tag          = var.confluence_version_tag
+  enable_synchrony     = var.confluence_collaborative_editing_enabled
 
   confluence_configuration = {
     helm_version = var.confluence_helm_chart_version
@@ -188,7 +191,8 @@ module "bitbucket" {
   db_master_username      = var.bitbucket_db_master_username
   db_master_password      = var.bitbucket_db_master_password
 
-  replica_count = var.bitbucket_replica_count
+  replica_count        = var.bitbucket_replica_count
+  installation_timeout = var.bitbucket_installation_timeout
 
   bitbucket_configuration = {
     helm_version = var.bitbucket_helm_chart_version

--- a/docs/docs/userguide/configuration/BAMBOO_CONFIGURATION.md
+++ b/docs/docs/userguide/configuration/BAMBOO_CONFIGURATION.md
@@ -20,6 +20,16 @@ For more information, see [Bamboo Version Tags](https://hub.docker.com/r/atlassi
 bamboo_version_tag = "<BAMBOO_VERSION_TAG>"
 ```
 
+### Installation timeout
+
+`bamboo_installation_timeout` defines the timeout (in minutes) for product **helm chart installation**. Different variables
+can influence how long it takes the application from installation to ready state. These can be dataset restoration,
+resource requirements, number of replicas and others.
+
+```terraform
+bamboo_installation_timeout = 10
+```
+
 ### License
 
 `bamboo_license` takes the license key of Bamboo product. Make sure that there is no new lines or spaces in license key.

--- a/docs/docs/userguide/configuration/BITBUCKET_CONFIGURATION.md
+++ b/docs/docs/userguide/configuration/BITBUCKET_CONFIGURATION.md
@@ -35,6 +35,16 @@ bitbucket_replica_count = 1
     [Cluster Autoscaler](https://github.com/kubernetes/autoscaler/tree/master/cluster-autoscaler) installed in the 
     cluster will monitor the amount of required resources and adjust the cluster size to accommodate the requested cpu and memory.
 
+### Installation timeout
+
+`bitbucket_installation_timeout` defines the timeout (in minutes) for product **helm chart installation**. Different variables 
+can influence how long it takes the application from installation to ready state. These can be dataset restoration, 
+resource requirements, number of replicas and others.
+
+```terraform
+bitbucket_installation_timeout = 10
+```
+
 ### License
 
 `bitbucket_license` takes the license key of Bitbucket product. Make sure that there is no new lines or spaces in license key.

--- a/docs/docs/userguide/configuration/CONFLUENCE_CONFIGURATION.md
+++ b/docs/docs/userguide/configuration/CONFLUENCE_CONFIGURATION.md
@@ -38,6 +38,16 @@ confluence_replica_count = 1
     [Cluster Autoscaler](https://github.com/kubernetes/autoscaler/tree/master/cluster-autoscaler) installed in the 
     cluster will monitor the amount of required resources and adjust the cluster size to accomodate the requested cpu and memory.
 
+### Installation timeout
+
+`confluence_installation_timeout` defines the timeout (in minutes) for product **helm chart installation**. Different variables
+can influence how long it takes the application from installation to ready state. These can be dataset restoration,
+resource requirements, number of replicas and others.
+
+```terraform
+confluence_installation_timeout = 10
+```
+
 ### License
 
 `confluence_license` takes the license key of Confluence product. Make sure that there is no new lines or spaces in license key.

--- a/docs/docs/userguide/configuration/JIRA_CONFIGURATION.md
+++ b/docs/docs/userguide/configuration/JIRA_CONFIGURATION.md
@@ -53,6 +53,16 @@ jira_replica_count = 1
     [Cluster Autoscaler](https://github.com/kubernetes/autoscaler/tree/master/cluster-autoscaler) installed in the 
     cluster will monitor the amount of required resources and adjust the cluster size to accomodate the requested cpu and memory.
 
+### Installation timeout
+
+`jira_installation_timeout` defines the timeout (in minutes) for product **helm chart installation**. Different variables
+can influence how long it takes the application from installation to ready state. These can be dataset restoration,
+resource requirements, number of replicas and others.
+
+```terraform
+jira_installation_timeout = 10
+```
+
 ### Instance resource configuration
 
 The following variables set number of CPU, amount of memory, maximum heap size and minimum heap size of Jira instance. (Used default values as example.)

--- a/modules/products/bamboo/helm.tf
+++ b/modules/products/bamboo/helm.tf
@@ -7,7 +7,7 @@ resource "helm_release" "bamboo" {
   repository = local.helm_chart_repository
   chart      = local.bamboo_helm_chart_name
   version    = local.bamboo_helm_chart_version
-  timeout    = 10 * 60
+  timeout    = var.installation_timeout * 60
 
   values = [
     yamlencode({

--- a/modules/products/bamboo/variables.tf
+++ b/modules/products/bamboo/variables.tf
@@ -40,6 +40,10 @@ variable "dataset_url" {
 variable "installation_timeout" {
   description = "Timeout for helm chart installation in minutes"
   type        = number
+  validation {
+    condition     = var.installation_timeout > 0
+    error_message = "Installation timeout needs to be a positive number."
+  }
 }
 
 variable "bamboo_configuration" {
@@ -93,7 +97,7 @@ variable "license" {
   type        = string
   sensitive   = true
   validation {
-    condition     = var.license != null
+    condition     = var.license != null && var.license != ""
     error_message = "License is not valid."
   }
 }

--- a/modules/products/bamboo/variables.tf
+++ b/modules/products/bamboo/variables.tf
@@ -37,6 +37,11 @@ variable "dataset_url" {
   type        = string
 }
 
+variable "installation_timeout" {
+  description = "Timeout for helm chart installation in minutes"
+  type        = number
+}
+
 variable "bamboo_configuration" {
   description = "Bamboo resource spec and chart version"
   type        = map(any)

--- a/modules/products/bitbucket/helm.tf
+++ b/modules/products/bitbucket/helm.tf
@@ -6,7 +6,7 @@ resource "helm_release" "bitbucket" {
   repository = local.helm_chart_repository
   chart      = local.product_name
   version    = local.bitbucket_helm_chart_version
-  timeout    = 15 * 60
+  timeout    = var.installation_timeout * 60
 
   values = [
     yamlencode({

--- a/modules/products/bitbucket/variables.tf
+++ b/modules/products/bitbucket/variables.tf
@@ -57,6 +57,11 @@ variable "replica_count" {
   type        = number
 }
 
+variable "installation_timeout" {
+  description = "Timeout for helm chart installation in minutes"
+  type        = number
+}
+
 variable "bitbucket_configuration" {
   description = "Bitbucket resource spec and chart version"
   type        = map(any)

--- a/modules/products/bitbucket/variables.tf
+++ b/modules/products/bitbucket/variables.tf
@@ -60,6 +60,10 @@ variable "replica_count" {
 variable "installation_timeout" {
   description = "Timeout for helm chart installation in minutes"
   type        = number
+  validation {
+    condition     = var.installation_timeout > 0
+    error_message = "Installation timeout needs to be a positive number."
+  }
 }
 
 variable "bitbucket_configuration" {
@@ -176,7 +180,6 @@ variable "db_master_username" {
   type        = string
   default     = null
 }
-
 
 variable "db_master_password" {
   description = "Master password for the RDS instance."

--- a/modules/products/confluence/helm.tf
+++ b/modules/products/confluence/helm.tf
@@ -8,7 +8,7 @@ resource "helm_release" "confluence" {
   repository = local.helm_chart_repository
   chart      = local.confluence_helm_chart_name
   version    = local.confluence_helm_chart_version
-  timeout    = 15 * 60 # autoscaler potentially needs to scale up the cluster
+  timeout    = var.installation_timeout * 60
 
   values = [
     yamlencode({

--- a/modules/products/confluence/variables.tf
+++ b/modules/products/confluence/variables.tf
@@ -54,6 +54,10 @@ variable "replica_count" {
 variable "installation_timeout" {
   description = "Timeout for helm chart installation in minutes"
   type        = number
+  validation {
+    condition     = var.installation_timeout > 0
+    error_message = "Installation timeout needs to be a positive number."
+  }
 }
 
 variable "confluence_configuration" {

--- a/modules/products/confluence/variables.tf
+++ b/modules/products/confluence/variables.tf
@@ -51,6 +51,11 @@ variable "replica_count" {
   type        = number
 }
 
+variable "installation_timeout" {
+  description = "Timeout for helm chart installation in minutes"
+  type        = number
+}
+
 variable "confluence_configuration" {
   description = "Confluence resource spec and chart version"
   type        = map(any)

--- a/modules/products/jira/helm.tf
+++ b/modules/products/jira/helm.tf
@@ -7,7 +7,7 @@ resource "helm_release" "jira" {
   repository = local.helm_chart_repository
   chart      = local.product_name
   version    = local.jira_helm_chart_version
-  timeout    = 15 * 60 # autoscaler potentially needs to scale up the cluster
+  timeout    = var.installation_timeout * 60
 
   values = [
     yamlencode({

--- a/modules/products/jira/variables.tf
+++ b/modules/products/jira/variables.tf
@@ -57,6 +57,11 @@ variable "replica_count" {
   type        = number
 }
 
+variable "installation_timeout" {
+  description = "Timeout for helm chart installation in minutes"
+  type        = number
+}
+
 variable "jira_configuration" {
   description = "Jira resource spec and chart version"
   type        = map(any)

--- a/modules/products/jira/variables.tf
+++ b/modules/products/jira/variables.tf
@@ -60,6 +60,10 @@ variable "replica_count" {
 variable "installation_timeout" {
   description = "Timeout for helm chart installation in minutes"
   type        = number
+  validation {
+    condition     = var.installation_timeout > 0
+    error_message = "Installation timeout needs to be a positive number."
+  }
 }
 
 variable "jira_configuration" {

--- a/test/unittest/bamboo_test.go
+++ b/test/unittest/bamboo_test.go
@@ -31,6 +31,23 @@ func TestBambooVariablesPopulatedWithValidValues(t *testing.T) {
 	assert.Equal(t, "https://atlassian.github.io/data-center-helm-charts", bambooAgent.AttributeValues["repository"])
 }
 
+func TestBambooVariablesPopulatedWithInvalidValues(t *testing.T) {
+	t.Parallel()
+
+	tfOptions := GenerateTFOptions(BambooIncorrectVariables, t, "products/bamboo")
+	_, err := terraform.InitAndPlanAndShowWithStructE(t, tfOptions)
+
+	assert.NotNil(t, err)
+	assert.Contains(t, err.Error(), "Invalid value for variable")
+	assert.Contains(t, err.Error(), "Invalid environment name. Valid name is up to 25 characters starting with")
+	assert.Contains(t, err.Error(), "Bamboo configuration is not valid.")
+	assert.Contains(t, err.Error(), "Bamboo database configuration is not valid.")
+	assert.Contains(t, err.Error(), "Installation timeout needs to be a positive number.")
+	assert.Contains(t, err.Error(), "Invalid email.")
+	assert.Contains(t, err.Error(), "Bamboo Agent configuration is not valid.")
+	assert.Contains(t, err.Error(), "License is not valid.")
+}
+
 // Variables
 
 var BambooCorrectVariables = map[string]interface{}{
@@ -81,5 +98,59 @@ var BambooCorrectVariables = map[string]interface{}{
 		"cpu":          "1",
 		"mem":          "1Gi",
 		"agent_count":  5,
+	},
+}
+
+var BambooIncorrectVariables = map[string]interface{}{
+	"environment_name": "1-is-an-invalid-environment-name",
+	"namespace":        "dummy-namespace",
+	"eks": map[string]interface{}{
+		"kubernetes_provider_config": map[string]interface{}{
+			"host":                   "dummy-host",
+			"token":                  "dummy-token",
+			"cluster_ca_certificate": "dummy-certificate",
+		},
+		"cluster_security_group": "dummy-sg",
+		"availability_zone":      "dummy-az",
+	},
+	"vpc":                     VpcDefaultModuleVariable,
+	"db_major_engine_version": "13",
+	"ingress": map[string]interface{}{
+		"outputs": map[string]interface{}{
+			"r53_zone":        "dummy_r53_zone",
+			"domain":          "dummy.domain.com",
+			"certificate_arn": "dummy_arn",
+			"lb_hostname":     "dummy.hostname.com.au",
+			"lb_zone_id":      "dummy_zone_id",
+		},
+	},
+	"dataset_url":          nil,
+	"installation_timeout": invalidTestTimeout,
+	"bamboo_configuration": map[string]interface{}{
+		"helm_version": "1.0.0",
+		"cpu":          "1",
+		"mem":          "1Gi",
+		"min_heap":     "256m",
+		"max_heap":     "512m",
+		"invalid":      "bamboo-configuration",
+	},
+	"db_configuration": map[string]interface{}{
+		"db_allocated_storage": 5,
+		"db_instance_class":    "dummy_db_instance_class",
+		"db_iops":              1000,
+		"db_name":              "bamboo",
+		"invalid":              "value",
+	},
+	"license":             "",
+	"admin_username":      "dummy_admin_username",
+	"admin_password":      "dummy_admin_password",
+	"admin_display_name":  "dummy_admin_display_name",
+	"admin_email_address": "invalid-email",
+	"bamboo_agent_configuration": map[string]interface{}{
+		"helm_version": "1.0.0",
+		"cpu":          "1",
+		"mem":          "1Gi",
+		"agent_count":  5,
+		"invalid":      "value",
 	},
 }

--- a/test/unittest/bamboo_test.go
+++ b/test/unittest/bamboo_test.go
@@ -19,6 +19,7 @@ func TestBambooVariablesPopulatedWithValidValues(t *testing.T) {
 	bamboo := plan.ResourcePlannedValuesMap[bambooKey]
 	assert.Equal(t, "deployed", bamboo.AttributeValues["status"])
 	assert.Equal(t, "bamboo", bamboo.AttributeValues["chart"])
+	assert.Equal(t, float64(testTimeout*60), bamboo.AttributeValues["timeout"])
 	assert.Equal(t, "https://atlassian.github.io/data-center-helm-charts", bamboo.AttributeValues["repository"])
 
 	// verify Bamboo Agents
@@ -55,7 +56,8 @@ var BambooCorrectVariables = map[string]interface{}{
 			"lb_zone_id":      "dummy_zone_id",
 		},
 	},
-	"dataset_url": nil,
+	"dataset_url":          nil,
+	"installation_timeout": testTimeout,
 	"bamboo_configuration": map[string]interface{}{
 		"helm_version": "1.0.0",
 		"cpu":          "1",

--- a/test/unittest/bitbucket_test.go
+++ b/test/unittest/bitbucket_test.go
@@ -53,6 +53,7 @@ func TestBitbucketVariablesNotProvided(t *testing.T) {
 	assert.Contains(t, err.Error(), "\"namespace\" is not set")
 	assert.Contains(t, err.Error(), "\"vpc\" is not set")
 	assert.Contains(t, err.Error(), "\"eks\" is not set")
+	assert.Contains(t, err.Error(), "\"installation_timeout\" is not set")
 	assert.Contains(t, err.Error(), "\"db_major_engine_version\" is not set")
 	assert.Contains(t, err.Error(), "\"db_allocated_storage\" is not set")
 	assert.Contains(t, err.Error(), "\"db_instance_class\" is not set")

--- a/test/unittest/bitbucket_test.go
+++ b/test/unittest/bitbucket_test.go
@@ -21,6 +21,7 @@ func TestBitbucketVariablesPopulatedWithValidValues(t *testing.T) {
 	bitbucket := plan.ResourcePlannedValuesMap[bitbucketKey]
 	assert.Equal(t, "deployed", bitbucket.AttributeValues["status"])
 	assert.Equal(t, "bitbucket", bitbucket.AttributeValues["chart"])
+	assert.Equal(t, float64(testTimeout*60), bitbucket.AttributeValues["timeout"])
 	assert.Equal(t, "https://atlassian.github.io/data-center-helm-charts", bitbucket.AttributeValues["repository"])
 }
 
@@ -101,7 +102,8 @@ var BitbucketCorrectVariables = map[string]interface{}{
 			"lb_zone_id":      "dummy_zone_id",
 		},
 	},
-	"replica_count": 1,
+	"replica_count":        1,
+	"installation_timeout": testTimeout,
 	"bitbucket_configuration": map[string]interface{}{
 		"helm_version": "1.2.0",
 		"cpu":          "1",

--- a/test/unittest/bitbucket_test.go
+++ b/test/unittest/bitbucket_test.go
@@ -38,6 +38,7 @@ func TestBitbucketVariablesPopulatedWithInvalidValues(t *testing.T) {
 	assert.Contains(t, err.Error(), "Bitbucket administrator configuration is not valid.")
 	assert.Contains(t, err.Error(), "Invalid elasticsearch replicas. Valid replicas is a positive integer in")
 	assert.Contains(t, err.Error(), "Bitbucket display name must be a non-empty value less than 255 characters.")
+	assert.Contains(t, err.Error(), "Installation timeout needs to be a positive number.")
 }
 
 func TestBitbucketVariablesNotProvided(t *testing.T) {

--- a/test/unittest/confluence_test.go
+++ b/test/unittest/confluence_test.go
@@ -62,6 +62,7 @@ func TestConfluenceVariablesNotProvided(t *testing.T) {
 	assert.Contains(t, err.Error(), "\"replica_count\" is not set")
 	assert.Contains(t, err.Error(), "\"confluence_configuration\" is not set")
 	assert.Contains(t, err.Error(), "\"enable_synchrony\" is not set")
+	assert.Contains(t, err.Error(), "\"installation_timeout\" is not set")
 }
 
 // Variables

--- a/test/unittest/confluence_test.go
+++ b/test/unittest/confluence_test.go
@@ -21,6 +21,7 @@ func TestConfluenceVariablesPopulatedWithValidValues(t *testing.T) {
 	confluence := plan.ResourcePlannedValuesMap[confluenceKey]
 	assert.Equal(t, "deployed", confluence.AttributeValues["status"])
 	assert.Equal(t, "confluence", confluence.AttributeValues["chart"])
+	assert.Equal(t, float64(testTimeout*60), confluence.AttributeValues["timeout"])
 	assert.Equal(t, "https://atlassian.github.io/data-center-helm-charts", confluence.AttributeValues["repository"])
 
 	dbModuleKey := "module.database.module.db.module.db_instance.aws_db_instance.this[0]"
@@ -94,7 +95,8 @@ var ConfluenceCorrectVariables = map[string]interface{}{
 		"db_iops":              1000,
 		"db_name":              "confluence",
 	},
-	"replica_count": 1,
+	"replica_count":        1,
+	"installation_timeout": testTimeout,
 	"confluence_configuration": map[string]interface{}{
 		"helm_version": "1.1.0",
 		"cpu":          "1",

--- a/test/unittest/confluence_test.go
+++ b/test/unittest/confluence_test.go
@@ -43,6 +43,7 @@ func TestConfluenceVariablesPopulatedWithInvalidValues(t *testing.T) {
 	assert.Contains(t, err.Error(), "Confluence database configuration is not valid.")
 	assert.Contains(t, err.Error(), "Confluence configuration is not valid.")
 	assert.Contains(t, err.Error(), "Invalid build number.")
+	assert.Contains(t, err.Error(), "Installation timeout needs to be a positive number.")
 }
 
 func TestConfluenceVariablesNotProvided(t *testing.T) {

--- a/test/unittest/jira_test.go
+++ b/test/unittest/jira_test.go
@@ -33,4 +33,5 @@ func TestJiraVariablesPopulatedWithInvalidValues(t *testing.T) {
 	assert.Contains(t, err.Error(), "Invalid value for variable")
 	assert.Contains(t, err.Error(), "Invalid environment name. Valid name is up to 25 characters starting with")
 	assert.Contains(t, err.Error(), "Jira configuration is not valid.")
+	assert.Contains(t, err.Error(), "Installation timeout needs to be a positive number.")
 }

--- a/test/unittest/jira_test.go
+++ b/test/unittest/jira_test.go
@@ -19,6 +19,7 @@ func TestJiraVariablesPopulatedWithValidValues(t *testing.T) {
 	jira := plan.ResourcePlannedValuesMap[jiraKey]
 	assert.Equal(t, "deployed", jira.AttributeValues["status"])
 	assert.Equal(t, "jira", jira.AttributeValues["chart"])
+	assert.Equal(t, float64(testTimeout*60), jira.AttributeValues["timeout"])
 	assert.Equal(t, "https://atlassian.github.io/data-center-helm-charts", jira.AttributeValues["repository"])
 }
 

--- a/test/unittest/test_variables.go
+++ b/test/unittest/test_variables.go
@@ -150,6 +150,7 @@ const masterPwd = "dummyPassword!"
 const invalidInputRdsInstanceId = "1-"
 const dbName = "duumy_name"
 const testTimeout = 10
+const invalidTestTimeout = -10
 
 var DbValidVariable = map[string]interface{}{
 	"product":                 inputProduct,
@@ -268,7 +269,7 @@ var BitbucketInvalidVariables = map[string]interface{}{
 	"display_name":         superLongStr,
 	"ingress":              map[string]interface{}{},
 	"replica_count":        1,
-	"installation_timeout": testTimeout,
+	"installation_timeout": invalidTestTimeout,
 	"bitbucket_configuration": map[string]interface{}{
 		"helm_version": "1.2.0",
 		"cpu":          "1",
@@ -322,7 +323,7 @@ var ConfluenceInvalidVariables = map[string]interface{}{
 		"invalid_db_config":    "extra",
 	},
 	"replica_count":        1,
-	"installation_timeout": testTimeout,
+	"installation_timeout": invalidTestTimeout,
 	"confluence_configuration": map[string]interface{}{
 		"helm_version": "1.1.0",
 		"cpu":          "1",
@@ -409,7 +410,7 @@ var JiraInvalidVariables = map[string]interface{}{
 		},
 	},
 	"replica_count":        1,
-	"installation_timeout": testTimeout,
+	"installation_timeout": invalidTestTimeout,
 	"jira_configuration": map[string]interface{}{
 		"helm_version":        "1.0.0",
 		"cpu":                 "2",

--- a/test/unittest/test_variables.go
+++ b/test/unittest/test_variables.go
@@ -265,9 +265,10 @@ var BitbucketInvalidVariables = map[string]interface{}{
 		"admin_display_name":  "dummy_admin_display_name",
 		"admin_email_address": "dummy_admin_email_address",
 	},
-	"display_name":  superLongStr,
-	"ingress":       map[string]interface{}{},
-	"replica_count": 1,
+	"display_name":         superLongStr,
+	"ingress":              map[string]interface{}{},
+	"replica_count":        1,
+	"installation_timeout": testTimeout,
 	"bitbucket_configuration": map[string]interface{}{
 		"helm_version": "1.2.0",
 		"cpu":          "1",
@@ -320,7 +321,8 @@ var ConfluenceInvalidVariables = map[string]interface{}{
 		"db_name":              "dummy_db_name",
 		"invalid_db_config":    "extra",
 	},
-	"replica_count": 1,
+	"replica_count":        1,
+	"installation_timeout": testTimeout,
 	"confluence_configuration": map[string]interface{}{
 		"helm_version": "1.1.0",
 		"cpu":          "1",
@@ -406,7 +408,8 @@ var JiraInvalidVariables = map[string]interface{}{
 			"lb_zone_id":      "dummy_zone_id",
 		},
 	},
-	"replica_count": 1,
+	"replica_count":        1,
+	"installation_timeout": testTimeout,
 	"jira_configuration": map[string]interface{}{
 		"helm_version":        "1.0.0",
 		"cpu":                 "2",

--- a/test/unittest/test_variables.go
+++ b/test/unittest/test_variables.go
@@ -149,6 +149,7 @@ const dbVersion = 13
 const masterPwd = "dummyPassword!"
 const invalidInputRdsInstanceId = "1-"
 const dbName = "duumy_name"
+const testTimeout = 10
 
 var DbValidVariable = map[string]interface{}{
 	"product":                 inputProduct,
@@ -363,7 +364,8 @@ var JiraCorrectVariables = map[string]interface{}{
 			"lb_zone_id":      "dummy_zone_id",
 		},
 	},
-	"replica_count": 1,
+	"replica_count":        1,
+	"installation_timeout": testTimeout,
 	"jira_configuration": map[string]interface{}{
 		"helm_version":        "1.0.0",
 		"cpu":                 "2",

--- a/variables.tf
+++ b/variables.tf
@@ -133,6 +133,12 @@ variable "jira_replica_count" {
   }
 }
 
+variable "jira_installation_timeout" {
+  description = "Timeout for helm chart installation in minutes"
+  type        = number
+  default     = 15
+}
+
 variable "jira_cpu" {
   description = "Number of CPUs for Jira instance"
   type        = string
@@ -306,6 +312,12 @@ variable "confluence_replica_count" {
   }
 }
 
+variable "confluence_installation_timeout" {
+  description = "Timeout for helm chart installation in minutes"
+  type        = number
+  default     = 15
+}
+
 variable "confluence_install_local_chart" {
   description = "If true installs Confluence using local Helm charts located in local_helm_charts_path"
   default     = false
@@ -462,6 +474,12 @@ variable "bitbucket_replica_count" {
     condition     = var.bitbucket_replica_count >= 0
     error_message = "Number of nodes must be greater than or equal to 0."
   }
+}
+
+variable "bitbucket_installation_timeout" {
+  description = "Timeout for helm chart installation in minutes"
+  type        = number
+  default     = 15
 }
 
 variable "bitbucket_license" {
@@ -710,6 +728,12 @@ variable "bamboo_version_tag" {
   description = "Version tag for Bamboo"
   type        = string
   default     = null
+}
+
+variable "bamboo_installation_timeout" {
+  description = "Timeout for helm chart installation in minutes"
+  type        = number
+  default     = 10
 }
 
 variable "bamboo_agent_version_tag" {

--- a/variables.tf
+++ b/variables.tf
@@ -733,7 +733,7 @@ variable "bamboo_version_tag" {
 variable "bamboo_installation_timeout" {
   description = "Timeout for helm chart installation in minutes"
   type        = number
-  default     = 10
+  default     = 15
 }
 
 variable "bamboo_agent_version_tag" {


### PR DESCRIPTION
## Pull request description

This change exposes the timeout of helm chart installation for each product.

* parameterized the timeout for `helm_release` resource
* exposed the timeout to the top level and config file
* the default timeout is set to the previous value and the default is only on the highest level (`variables.tf`)
* included timeout in the unit tests

## Checklist
- [x] I have successful end to end tests run (with & without domain)
- [x] I have added unit tests (if applicable)
- [x] I have user documentation (if applicable)
