### PR TITLE
TFKUBE-448: Add limits for the elasticsearch helm chart

### DIFF
--- a/config.tfvars
+++ b/config.tfvars
@@ -271,10 +271,12 @@ bitbucket_db_name = "bitbucket"
 #bitbucket_nfs_limits_memory   = "<LIMITS_MEMORY>"
 
 # Elasticsearch resource configuration for Bitbucket
-#bitbucket_elasticsearch_cpu      = "<REQUESTS_CPU>"
-#bitbucket_elasticsearch_mem      = "<REQUESTS_MEMORY>"
-#bitbucket_elasticsearch_storage  = "<REQUESTS_STORAGE>"
-#bitbucket_elasticsearch_replicas = "<NUMBER_OF_NODES>"
+#bitbucket_elasticsearch_requests_cpu    = "<REQUESTS_CPU>"
+#bitbucket_elasticsearch_requests_memory = "<REQUESTS_MEMORY>"
+#bitbucket_elasticsearch_limits_cpu      = "<LIMITS_CPU>"
+#bitbucket_elasticsearch_limits_memory   = "<LIMITS_MEMORY>"
+#bitbucket_elasticsearch_storage         = "<REQUESTS_STORAGE>"
+#bitbucket_elasticsearch_replicas        = "<NUMBER_OF_NODES>"
 
 # Dataset Restore
 

--- a/dc-infrastructure.tf
+++ b/dc-infrastructure.tf
@@ -221,10 +221,12 @@ module "bitbucket" {
   nfs_limits_cpu      = var.bitbucket_nfs_limits_cpu
   nfs_limits_memory   = var.bitbucket_nfs_limits_memory
 
-  elasticsearch_cpu      = var.bitbucket_elasticsearch_cpu
-  elasticsearch_mem      = var.bitbucket_elasticsearch_mem
-  elasticsearch_storage  = var.bitbucket_elasticsearch_storage
-  elasticsearch_replicas = var.bitbucket_elasticsearch_replicas
+  elasticsearch_requests_cpu    = var.bitbucket_elasticsearch_requests_cpu
+  elasticsearch_requests_memory = var.bitbucket_elasticsearch_requests_memory
+  elasticsearch_limits_cpu      = var.bitbucket_elasticsearch_limits_cpu
+  elasticsearch_limits_memory   = var.bitbucket_elasticsearch_limits_memory
+  elasticsearch_storage         = var.bitbucket_elasticsearch_storage
+  elasticsearch_replicas        = var.bitbucket_elasticsearch_replicas
 
   shared_home_snapshot_id = var.bitbucket_shared_home_snapshot_id
 }

--- a/docs/docs/userguide/configuration/BITBUCKET_CONFIGURATION.md
+++ b/docs/docs/userguide/configuration/BITBUCKET_CONFIGURATION.md
@@ -170,10 +170,12 @@ The following variables set the request for number of CPU, amount of memory, amo
 
 ```terraform
 # Elasticsearch resource configuration for Bitbucket
-bitbucket_elasticsearch_cpu      = "0.25"
-bitbucket_elasticsearch_mem      = "1Gi"
-bitbucket_elasticsearch_storage  = 10
-bitbucket_elasticsearch_replicas = 2
+bitbucket_elasticsearch_requests_cpu    = "0.5"
+bitbucket_elasticsearch_requests_memory = "0.5Gi"
+bitbucket_elasticsearch_limits_cpu      = "1"
+bitbucket_elasticsearch_limits_memory   = "1Gi"
+bitbucket_elasticsearch_storage         = 10
+bitbucket_elasticsearch_replicas        = 2
 ```
 
 

--- a/modules/products/bitbucket/elasticsearch.tf
+++ b/modules/products/bitbucket/elasticsearch.tf
@@ -20,8 +20,12 @@ resource "helm_release" "elasticsearch" {
 
       resources = {
         requests = {
-          cpu    = var.elasticsearch_cpu
-          memory = var.elasticsearch_mem
+          cpu    = var.elasticsearch_requests_cpu
+          memory = var.elasticsearch_requests_memory
+        }
+        limits = {
+          cpu    = var.elasticsearch_limits_cpu
+          memory = var.elasticsearch_limits_memory
         }
       },
       volumeClaimTemplate = {

--- a/modules/products/bitbucket/variables.tf
+++ b/modules/products/bitbucket/variables.tf
@@ -135,13 +135,23 @@ variable "elasticsearch_endpoint" {
   default     = null
 }
 
-variable "elasticsearch_cpu" {
-  description = "Number of CPUs for elasticsearch instance."
+variable "elasticsearch_requests_cpu" {
+  description = "Number of CPUs requested for elasticsearch instance."
   type        = string
 }
 
-variable "elasticsearch_mem" {
-  description = "Amount of memory for elasticsearch instance."
+variable "elasticsearch_requests_memory" {
+  description = "Amount of memory requested for elasticsearch instance."
+  type        = string
+}
+
+variable "elasticsearch_limits_cpu" {
+  description = "CPU limit for elasticsearch instance."
+  type        = string
+}
+
+variable "elasticsearch_limits_memory" {
+  description = "Memory limit for elasticsearch instance."
   type        = string
 }
 

--- a/test/unittest/bitbucket_test.go
+++ b/test/unittest/bitbucket_test.go
@@ -61,8 +61,10 @@ func TestBitbucketVariablesNotProvided(t *testing.T) {
 	assert.Contains(t, err.Error(), "\"db_iops\" is not set")
 	assert.Contains(t, err.Error(), "\"bitbucket_configuration\" is not set")
 	assert.Contains(t, err.Error(), "\"admin_configuration\" is not set")
-	assert.Contains(t, err.Error(), "\"elasticsearch_cpu\" is not set")
-	assert.Contains(t, err.Error(), "\"elasticsearch_mem\" is not set")
+	assert.Contains(t, err.Error(), "\"elasticsearch_requests_cpu\" is not set")
+	assert.Contains(t, err.Error(), "\"elasticsearch_requests_memory\" is not set")
+	assert.Contains(t, err.Error(), "\"elasticsearch_limits_cpu\" is not set")
+	assert.Contains(t, err.Error(), "\"elasticsearch_limits_memory\" is not set")
 	assert.Contains(t, err.Error(), "\"elasticsearch_storage\" is not set")
 	assert.Contains(t, err.Error(), "\"elasticsearch_replicas\" is not set")
 	assert.NotContains(t, err.Error(), "display_name")
@@ -114,13 +116,15 @@ var BitbucketCorrectVariables = map[string]interface{}{
 		"max_heap":     "512m",
 		"license":      "dummy_license",
 	},
-	"shared_home_size":       "10Gi",
-	"nfs_requests_cpu":       "0.25",
-	"nfs_requests_memory":    "256Mi",
-	"nfs_limits_cpu":         "0.25",
-	"nfs_limits_memory":      "256Mi",
-	"elasticsearch_cpu":      "1",
-	"elasticsearch_mem":      "1Gi",
-	"elasticsearch_storage":  10,
-	"elasticsearch_replicas": 2,
+	"shared_home_size":              "10Gi",
+	"nfs_requests_cpu":              "0.25",
+	"nfs_requests_memory":           "256Mi",
+	"nfs_limits_cpu":                "0.25",
+	"nfs_limits_memory":             "256Mi",
+	"elasticsearch_requests_cpu":    "1",
+	"elasticsearch_requests_memory": "1Gi",
+	"elasticsearch_limits_cpu":      "1",
+	"elasticsearch_limits_memory":   "1Gi",
+	"elasticsearch_storage":         10,
+	"elasticsearch_replicas":        2,
 }

--- a/test/unittest/test_variables.go
+++ b/test/unittest/test_variables.go
@@ -279,14 +279,16 @@ var BitbucketInvalidVariables = map[string]interface{}{
 		"license":      "dummy_license",
 		"invalid":      "bitbucket-configuration",
 	},
-	"nfs_requests_cpu":       "0.25",
-	"nfs_requests_memory":    "256Mi",
-	"nfs_limits_cpu":         "0.25",
-	"nfs_limits_memory":      "256Mi",
-	"elasticsearch_cpu":      "1",
-	"elasticsearch_mem":      "1Gi",
-	"elasticsearch_storage":  10,
-	"elasticsearch_replicas": 9, // invalid, should be [2,8]
+	"nfs_requests_cpu":              "0.25",
+	"nfs_requests_memory":           "256Mi",
+	"nfs_limits_cpu":                "0.25",
+	"nfs_limits_memory":             "256Mi",
+	"elasticsearch_requests_cpu":    "1",
+	"elasticsearch_requests_memory": "1Gi",
+	"elasticsearch_limits_cpu":      "1",
+	"elasticsearch_limits_memory":   "1Gi",
+	"elasticsearch_storage":         10,
+	"elasticsearch_replicas":        9, // invalid, should be [2,8]
 }
 
 var superLongStr = "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nam orci mauris, cursus sit amet tortor sit amet, aliquam dapibus magna. In sodales felis in ipsum euismod tempor. Phasellus mattis, justo id auctor lacinia, ipsum nulla sodales massa, ac porttitor arcu sem et quam."

--- a/variables.tf
+++ b/variables.tf
@@ -610,16 +610,28 @@ variable "bitbucket_nfs_limits_memory" {
   default     = "2Gi"
 }
 
-variable "bitbucket_elasticsearch_cpu" {
+variable "bitbucket_elasticsearch_requests_cpu" {
   description = "Number of CPUs for Bitbucket elasticsearch instance."
   type        = string
   default     = "0.25"
 }
 
-variable "bitbucket_elasticsearch_mem" {
+variable "bitbucket_elasticsearch_requests_memory" {
   description = "Amount of memory for Bitbucket elasticsearch instance."
   type        = string
   default     = "1Gi"
+}
+
+variable "bitbucket_elasticsearch_limits_cpu" {
+  description = "CPUs limit for elasticsearch instance."
+  type        = string
+  default     = "0.5"
+}
+
+variable "bitbucket_elasticsearch_limits_memory" {
+  description = "Memory limit for elasticsearch instance."
+  type        = string
+  default     = "2Gi"
 }
 
 variable "bitbucket_elasticsearch_storage" {


### PR DESCRIPTION
## Pull request description

This change fixes bug when the user is installing Bitbucket and also redefine the Elasticsearch requests with higher values (beyond the default `limits` values in the [Elasticsearch helm chart](https://github.com/elastic/helm-charts/blob/main/elasticsearch/values.yaml#L94)). It is not possible to have `requests` being higher than `limits` and therefore the Elasticsearch statefulSet fails to deploy.

* Added `elasticsearch_limits_memory`, `elasticsearch_limits_cpu` variables with defaults (double the `requests`).
* Renamed the elasticsearch requests to align them with the `nfs` module
* Added the variables into user documentation
* Fixed the unit tests

## Checklist
- [x] I have successful end to end tests run (with & without domain)
- [x] I have added unit tests (if applicable)
- [x] I have user documentation (if applicable)
