### PR TITLE
TFKUBE-453: Add additionalJvmArgs in Jira so It can pick up any existing index snapshot in share-home

### DIFF
--- a/modules/products/jira/helm.tf
+++ b/modules/products/jira/helm.tf
@@ -64,7 +64,7 @@ resource "helm_release" "jira" {
     local.ingress_settings,
     local.context_path_settings,
     local.version_tag,
-    local.ignore_index_check,
+    local.reuse_old_index_snapshot
   ]
 }
 

--- a/modules/products/jira/helm.tf
+++ b/modules/products/jira/helm.tf
@@ -32,6 +32,7 @@ resource "helm_release" "jira" {
             }
           }
         }
+        additionalJvmArgs = concat(local.ignore_index_check, local.reuse_old_index_snapshot)
       }
       database = {
         type   = "postgres72"
@@ -64,7 +65,6 @@ resource "helm_release" "jira" {
     local.ingress_settings,
     local.context_path_settings,
     local.version_tag,
-    local.reuse_old_index_snapshot
   ]
 }
 

--- a/modules/products/jira/locals.tf
+++ b/modules/products/jira/locals.tf
@@ -44,11 +44,12 @@ locals {
     }
   }) : yamlencode({})
 
+  # After restoring the snapshot of the Jira database, a re-index is required. To avoid interruption in the Jira
+  # service we should exclude indexing status from the health check process.
+  # For more info see: https://jira.atlassian.com/browse/JRASERVER-66970
+  ignore_index_check = var.db_snapshot_id != null ? ["-Dcom.atlassian.jira.status.index.check=false"] :[]
+
   # By default, Jira accepts an index snapshot taken within 24hours. In order to use snapshot older than 24hours we need to update following property value.
   # It is set to 10 years.
-  reuse_old_index_snapshot = var.shared_home_snapshot_id != null ? yamlencode({
-    jira = {
-      additionalJvmArgs = ["-Dcom.atlassian.jira.startup.max.age.of.usable.index.snapshot.in.hours=${local.ageOfUsableIndexSnapshot}"]
-    }
-  }) : yamlencode({})
+  reuse_old_index_snapshot = var.shared_home_snapshot_id != null ? ["-Dcom.atlassian.jira.startup.max.age.of.usable.index.snapshot.in.hours=${local.ageOfUsableIndexSnapshot}"]:[]
 }

--- a/modules/products/jira/locals.tf
+++ b/modules/products/jira/locals.tf
@@ -16,6 +16,7 @@ locals {
 
   domain_supplied     = var.ingress.outputs.domain != null ? true : false
   product_domain_name = local.domain_supplied ? "${local.product_name}.${var.ingress.outputs.domain}" : null
+  ageOfUsableIndexSnapshot = 24 * 365 * 10
 
   # ingress settings for Jira service
   ingress_settings = yamlencode({
@@ -47,7 +48,7 @@ locals {
   # It is set to 10 years.
   reuse_old_index_snapshot = var.shared_home_snapshot_id != null ? yamlencode({
     jira = {
-      additionalJvmArgs = ["-Dcom.atlassian.jira.startup.max.age.of.usable.index.snapshot.in.hours=87600"]
+      additionalJvmArgs = ["-Dcom.atlassian.jira.startup.max.age.of.usable.index.snapshot.in.hours=${local.ageOfUsableIndexSnapshot}"]
     }
   }) : yamlencode({})
 }

--- a/modules/products/jira/locals.tf
+++ b/modules/products/jira/locals.tf
@@ -16,7 +16,7 @@ locals {
 
   domain_supplied     = var.ingress.outputs.domain != null ? true : false
   product_domain_name = local.domain_supplied ? "${local.product_name}.${var.ingress.outputs.domain}" : null
-  ageOfUsableIndexSnapshot = 24 * 365 * 10
+  ageOfUsableIndexSnapshot = 24 * 365 * 10 # 10 years
 
   # ingress settings for Jira service
   ingress_settings = yamlencode({

--- a/modules/products/jira/locals.tf
+++ b/modules/products/jira/locals.tf
@@ -43,12 +43,11 @@ locals {
     }
   }) : yamlencode({})
 
-  # After restoring the snapshot of the Jira database, a re-index is required. To avoid interruption in the Jira
-  # service we should exclude indexing status from the health check process.
-  # For more info see: https://jira.atlassian.com/browse/JRASERVER-66970
-  ignore_index_check = var.db_snapshot_id != null ? yamlencode({
+  # By default, Jira accepts an index snapshot taken within 24hours. In order to use snapshot older than 24hours we need to update following property value.
+  # It is set to 10 years.
+  reuse_old_index_snapshot = var.shared_home_snapshot_id != null ? yamlencode({
     jira = {
-      additionalJvmArgs = ["-Dcom.atlassian.jira.status.index.check=false"]
+      additionalJvmArgs = ["-Dcom.atlassian.jira.startup.max.age.of.usable.index.snapshot.in.hours=87600"]
     }
   }) : yamlencode({})
 }


### PR DESCRIPTION
## Pull request description

Valid index snapshot for Jira node should be by default created within 24 hours prior to Jira Node creation. This is an issue as dc-apt team won't distribute new shared-home snapshot everyday.

com.atlassian.jira.startup.max.age.of.usable.index.snapshot.in.hours allows user to customise the period.

It is set to 10 years for now but when jira-server team introduce infinite flag(-1) we can update it later

## Checklist
- [x] I have successful end to end tests run (with & without domain)
- [x] I have added unit tests (if applicable)
- [x] I have user documentation (if applicable)
