### PR TITLE
TFKUBE-462: Downgrade kubectl to 1.23.6

### DIFF
--- a/.github/workflows/e2e-test-no-domain.yaml
+++ b/.github/workflows/e2e-test-no-domain.yaml
@@ -28,10 +28,10 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
 
-      - name: Setup AWS CLI
-        uses: unfor19/install-aws-cli-action@v1.0.3
+      - name: Pin Kubectl version
+        uses: azure/setup-kubectl@v2.0
         with:
-          version: 2.6.3
+          version: 'v1.23.6'
 
       - name: Setup Go environment
         uses: actions/setup-go@v2.1.4
@@ -65,6 +65,7 @@ jobs:
         working-directory: test/
         run: |
           aws --version
+          kubectl version
           set -o pipefail
           go test ./e2etest -v -timeout 85m -run Installer | tee ./e2etest/artifacts/e2etest.log
 

--- a/.github/workflows/e2e-test-no-domain.yaml
+++ b/.github/workflows/e2e-test-no-domain.yaml
@@ -28,6 +28,11 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
 
+      - name: Setup AWS CLI
+        uses: unfor19/install-aws-cli-action@v1.0.3
+        with:
+          version: 2.6.3
+
       - name: Setup Go environment
         uses: actions/setup-go@v2.1.4
         with:
@@ -59,6 +64,7 @@ jobs:
         id: e2e-test
         working-directory: test/
         run: |
+          aws --version
           set -o pipefail
           go test ./e2etest -v -timeout 85m -run Installer | tee ./e2etest/artifacts/e2etest.log
 

--- a/.github/workflows/e2e-test-no-domain.yaml
+++ b/.github/workflows/e2e-test-no-domain.yaml
@@ -64,8 +64,6 @@ jobs:
         id: e2e-test
         working-directory: test/
         run: |
-          aws --version
-          kubectl version
           set -o pipefail
           go test ./e2etest -v -timeout 85m -run Installer | tee ./e2etest/artifacts/e2etest.log
 

--- a/.github/workflows/e2e-test-no-domain.yaml
+++ b/.github/workflows/e2e-test-no-domain.yaml
@@ -33,6 +33,11 @@ jobs:
         with:
           go-version: 1.17
 
+      - name: Setup AWS CLI
+        uses: unfor19/install-aws-cli-action@v1.0.3
+        with:
+          version: 2.6.3
+
       - name: Setup dependencies
         id: setup-dependencies
         working-directory: test/
@@ -59,6 +64,7 @@ jobs:
         id: e2e-test
         working-directory: test/
         run: |
+          aws --version
           set -o pipefail
           go test ./e2etest -v -timeout 85m -run Installer | tee ./e2etest/artifacts/e2etest.log
 

--- a/.github/workflows/e2e-test-no-domain.yaml
+++ b/.github/workflows/e2e-test-no-domain.yaml
@@ -33,11 +33,6 @@ jobs:
         with:
           go-version: 1.17
 
-      - name: Setup AWS CLI
-        uses: unfor19/install-aws-cli-action@v1.0.3
-        with:
-          version: 2.6.3
-
       - name: Setup dependencies
         id: setup-dependencies
         working-directory: test/
@@ -64,7 +59,6 @@ jobs:
         id: e2e-test
         working-directory: test/
         run: |
-          aws --version
           set -o pipefail
           go test ./e2etest -v -timeout 85m -run Installer | tee ./e2etest/artifacts/e2etest.log
 

--- a/.github/workflows/e2e-test-with-domain.yaml
+++ b/.github/workflows/e2e-test-with-domain.yaml
@@ -27,6 +27,11 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v2
+        
+      - name: Pin Kubectl version
+        uses: azure/setup-kubectl@v2.0
+        with:
+          version: 'v1.23.6'
 
       - name: Setup Go environment
         uses: actions/setup-go@v2.1.4

--- a/providers.tf
+++ b/providers.tf
@@ -12,7 +12,7 @@ provider "kubernetes" {
   host                   = module.base-infrastructure.eks.kubernetes_provider_config.host
   cluster_ca_certificate = module.base-infrastructure.eks.kubernetes_provider_config.cluster_ca_certificate
   exec {
-    api_version = "client.authentication.k8s.io/v1alpha1"
+    api_version = "client.authentication.k8s.io/v1beta1"
     args        = ["eks", "get-token", "--cluster-name", local.cluster_name]
     command     = "aws"
   }
@@ -23,7 +23,7 @@ provider "helm" {
     host                   = module.base-infrastructure.eks.kubernetes_provider_config.host
     cluster_ca_certificate = module.base-infrastructure.eks.kubernetes_provider_config.cluster_ca_certificate
     exec {
-      api_version = "client.authentication.k8s.io/v1alpha1"
+      api_version = "client.authentication.k8s.io/v1beta1"
       args        = ["eks", "get-token", "--cluster-name", local.cluster_name]
       command     = "aws"
     }

--- a/providers.tf
+++ b/providers.tf
@@ -12,7 +12,7 @@ provider "kubernetes" {
   host                   = module.base-infrastructure.eks.kubernetes_provider_config.host
   cluster_ca_certificate = module.base-infrastructure.eks.kubernetes_provider_config.cluster_ca_certificate
   exec {
-    api_version = "client.authentication.k8s.io/v1beta1"
+    api_version = "client.authentication.k8s.io/v1alpha1"
     args        = ["eks", "get-token", "--cluster-name", local.cluster_name]
     command     = "aws"
   }
@@ -23,7 +23,7 @@ provider "helm" {
     host                   = module.base-infrastructure.eks.kubernetes_provider_config.host
     cluster_ca_certificate = module.base-infrastructure.eks.kubernetes_provider_config.cluster_ca_certificate
     exec {
-      api_version = "client.authentication.k8s.io/v1beta1"
+      api_version = "client.authentication.k8s.io/v1alpha1"
       args        = ["eks", "get-token", "--cluster-name", local.cluster_name]
       command     = "aws"
     }


### PR DESCRIPTION
## Pull request description

Bumping up AWS CLI  version to 2.6.3 still result to `invalid apiVersion "client.authentication.k8s.io/v1alpha1"`.

Tried to update api version to v1beta1(figure 1) but It seems to be that [kubernetes provider](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs#exec-plugins) only expect `v1alpha1` as an acceptable api_version (figure2).  and the latest kubernetes provider version(2.11.0) doesn't look it it is supporting `v1beta1` yet.

figure1
<img width="830" alt="Screen Shot 2022-05-09 at 4 08 26 pm" src="https://user-images.githubusercontent.com/85263332/167351080-176ea54f-bbf6-4eca-91ae-44bc7783a70d.png">

figure2
<img width="1920" alt="Screen Shot 2022-05-09 at 4 01 17 pm" src="https://user-images.githubusercontent.com/85263332/167349494-5142086f-5629-4165-8f40-1c2e1384be84.png">

Going back to quick-fix solution. locking kubectl version to 1.23.6 worked.

## Checklist
- [x] I have successful end to end tests run (with & without domain)
- [x] I have added unit tests (if applicable)
- [x] I have user documentation (if applicable)
