### PR TITLE
TFKUBE-465: Add DCAPT analytics property

### DIFF
--- a/modules/products/bamboo/helm.tf
+++ b/modules/products/bamboo/helm.tf
@@ -24,6 +24,7 @@ resource "helm_release" "bamboo" {
             }
           }
         }
+        additionalJvmArgs = concat(local.dcapt_analytics_property)
       }
       database = {
         type = "postgresql"

--- a/modules/products/bamboo/locals.tf
+++ b/modules/products/bamboo/locals.tf
@@ -116,4 +116,7 @@ locals {
   }) : yamlencode({})
 
   dataset_filename = "bamboo_dataset_to_import.zip"
+
+  # DC App Performance Toolkit analytics
+  dcapt_analytics_property = ["-Dcom.atlassian.dcapt.deployment=terraform"]
 }

--- a/modules/products/bitbucket/helm.tf
+++ b/modules/products/bitbucket/helm.tf
@@ -1,6 +1,7 @@
 # Install Helm chart for Bitbucket Data Center.
 
 resource "helm_release" "bitbucket" {
+  depends_on = [kubernetes_job.pre_install]
   name       = local.product_name
   namespace  = var.namespace
   repository = local.helm_chart_repository
@@ -30,6 +31,7 @@ resource "helm_release" "bitbucket" {
         elasticSearch = {
           baseUrl = local.elasticsearch_endpoint
         }
+        additionalJvmArgs = concat(local.dcapt_analytics_property)
       }
       database = {
         url    = module.database.rds_jdbc_connection

--- a/modules/products/bitbucket/locals.tf
+++ b/modules/products/bitbucket/locals.tf
@@ -82,4 +82,7 @@ locals {
   }) : yamlencode({})
 
   bitbucket_ingress_url = local.domain_supplied ? "https://${local.product_domain_name}" : "http://${var.ingress.outputs.lb_hostname}/${local.product_name}"
+
+  # DC App Performance Toolkit analytics
+  dcapt_analytics_property = ["-Dcom.atlassian.dcapt.deployment=terraform"]
 }

--- a/modules/products/confluence/helm.tf
+++ b/modules/products/confluence/helm.tf
@@ -29,6 +29,7 @@ resource "helm_release" "confluence" {
             }
           }
         }
+        additionalJvmArgs = concat(local.dcapt_analytics_property)
       }
       database = {
         type = "postgresql"

--- a/modules/products/confluence/locals.tf
+++ b/modules/products/confluence/locals.tf
@@ -87,4 +87,7 @@ locals {
       ]
     }
   }) : yamlencode({})
+
+  # DC App Performance Toolkit analytics
+  dcapt_analytics_property = ["-Dcom.atlassian.dcapt.deployment=terraform"]
 }

--- a/modules/products/jira/helm.tf
+++ b/modules/products/jira/helm.tf
@@ -32,7 +32,7 @@ resource "helm_release" "jira" {
             }
           }
         }
-        additionalJvmArgs = concat(local.ignore_index_check, local.reuse_old_index_snapshot)
+        additionalJvmArgs = concat(local.ignore_index_check, local.reuse_old_index_snapshot, local.dcapt_analytics_property)
       }
       database = {
         type   = "postgres72"

--- a/modules/products/jira/locals.tf
+++ b/modules/products/jira/locals.tf
@@ -14,8 +14,8 @@ locals {
 
   rds_instance_id = format("atlas-%s-%s-db", var.environment_name, local.product_name)
 
-  domain_supplied     = var.ingress.outputs.domain != null ? true : false
-  product_domain_name = local.domain_supplied ? "${local.product_name}.${var.ingress.outputs.domain}" : null
+  domain_supplied          = var.ingress.outputs.domain != null ? true : false
+  product_domain_name      = local.domain_supplied ? "${local.product_name}.${var.ingress.outputs.domain}" : null
   ageOfUsableIndexSnapshot = 24 * 365 * 10 # 10 years
 
   # ingress settings for Jira service
@@ -47,9 +47,12 @@ locals {
   # After restoring the snapshot of the Jira database, a re-index is required. To avoid interruption in the Jira
   # service we should exclude indexing status from the health check process.
   # For more info see: https://jira.atlassian.com/browse/JRASERVER-66970
-  ignore_index_check = var.db_snapshot_id != null ? ["-Dcom.atlassian.jira.status.index.check=false"] :[]
+  ignore_index_check = var.db_snapshot_id != null ? ["-Dcom.atlassian.jira.status.index.check=false"] : []
 
   # By default, Jira accepts an index snapshot taken within 24hours. In order to use snapshot older than 24hours we need to update following property value.
   # It is set to 10 years.
-  reuse_old_index_snapshot = var.shared_home_snapshot_id != null ? ["-Dcom.atlassian.jira.startup.max.age.of.usable.index.snapshot.in.hours=${local.ageOfUsableIndexSnapshot}"]:[]
+  reuse_old_index_snapshot = var.shared_home_snapshot_id != null ? ["-Dcom.atlassian.jira.startup.max.age.of.usable.index.snapshot.in.hours=${local.ageOfUsableIndexSnapshot}"] : []
+
+  # DC App Performance Toolkit analytics
+  dcapt_analytics_property = ["-Dcom.atlassian.dcapt.deployment=terraform"]
 }


### PR DESCRIPTION
## Pull request description

* Added `com.atlassian.dcapt.deployment=terraform` property to gather analytics in DCAPT
* Added depedency on the `pre-install` job for Bitbucket

URLs to show property:
Jira - `/jira/secure/admin/ViewSystemInfo.jspa`
Confluence - `/confluence/admin/systeminfo.action`
Bitbucket - `/bitbucket/plugins/servlet/troubleshooting/view/`
Bamboo - `/bamboo/admin/systemInfo.action`

## Checklist

- [ ] I have successful end to end tests run (with & without domain)
- [x] I have added unit tests (if applicable)
- [x] I have user documentation (if applicable)
