### PR TITLE
TFKUBE-466: Update helm charts from 1.2.0 to 1.3.0

### DIFF
--- a/config.tfvars
+++ b/config.tfvars
@@ -46,7 +46,7 @@ max_cluster_capacity = 5
 ################################################################################
 
 # Helm chart version of Jira
-jira_helm_chart_version = "1.2.0"
+jira_helm_chart_version = "1.3.0"
 
 # Number of Jira application nodes
 # Note: For initial installation this value needs to be set to 1 and it can be changed only after Jira is fully
@@ -125,7 +125,7 @@ jira_db_name = "jira"
 ################################################################################
 
 # Helm chart version of Confluence
-confluence_helm_chart_version = "1.2.0"
+confluence_helm_chart_version = "1.3.0"
 
 # Number of Confluence application nodes
 # Note: For initial installation this value needs to be set to 1 and it can be changed only after Confluence is fully
@@ -205,7 +205,7 @@ confluence_collaborative_editing_enabled = true
 ################################################################################
 
 # Helm chart version of Bitbucket
-bitbucket_helm_chart_version = "1.2.0"
+bitbucket_helm_chart_version = "1.3.0"
 
 # Number of Bitbucket application nodes
 bitbucket_replica_count = 1
@@ -304,8 +304,8 @@ bitbucket_db_name = "bitbucket"
 ################################################################################
 
 # Helm chart version of Bamboo and Bamboo agent instances
-bamboo_helm_chart_version       = "1.2.0"
-bamboo_agent_helm_chart_version = "1.2.0"
+bamboo_helm_chart_version       = "1.3.0"
+bamboo_agent_helm_chart_version = "1.3.0"
 
 # By default, Bamboo and the Bamboo Agent will use the versions defined in their respective Helm charts:
 # https://github.com/atlassian/data-center-helm-charts/blob/main/src/main/charts/bamboo/Chart.yaml

--- a/test/unittest/test_variables.go
+++ b/test/unittest/test_variables.go
@@ -271,7 +271,7 @@ var BitbucketInvalidVariables = map[string]interface{}{
 	"replica_count":        1,
 	"installation_timeout": invalidTestTimeout,
 	"bitbucket_configuration": map[string]interface{}{
-		"helm_version": "1.2.0",
+		"helm_version": "1.3.0",
 		"cpu":          "1",
 		"mem":          "1Gi",
 		"min_heap":     "256m",

--- a/variables.tf
+++ b/variables.tf
@@ -108,7 +108,7 @@ variable "logging_bucket" {
 variable "jira_helm_chart_version" {
   description = "Version of Jira Helm chart"
   type        = string
-  default     = "1.2.0"
+  default     = "1.3.0"
 }
 
 variable "jira_image_repository" {
@@ -293,7 +293,7 @@ variable "confluence_license" {
 variable "confluence_helm_chart_version" {
   description = "Version of confluence Helm chart"
   type        = string
-  default     = "1.2.0"
+  default     = "1.3.0"
 }
 
 variable "confluence_version_tag" {
@@ -457,7 +457,7 @@ variable "confluence_shared_home_snapshot_id" {
 variable "bitbucket_helm_chart_version" {
   description = "Version of Bitbucket Helm chart"
   type        = string
-  default     = "1.2.0"
+  default     = "1.3.0"
 }
 
 variable "bitbucket_version_tag" {
@@ -726,14 +726,14 @@ variable "number_of_bamboo_agents" {
 
 variable "bamboo_helm_chart_version" {
   description = "Version of Bamboo Helm chart"
-  default     = "1.2.0"
+  default     = "1.3.0"
   type        = string
 }
 
 variable "bamboo_agent_helm_chart_version" {
   description = "Version of Bamboo agent Helm chart"
   type        = string
-  default     = "1.2.0"
+  default     = "1.3.0"
 }
 
 variable "bamboo_version_tag" {


### PR DESCRIPTION
## Pull request description

Update default helm chart versions from `1.2.0` to `1.3.0`.

This PR can serve as a reference for what will need to be changed when we release a new version of helm charts.

## Checklist
- [x] I have successful end to end tests run (with & without domain)
- [x] I have added unit tests (if applicable)
- [x] I have user documentation (if applicable)
