### PR TITLE
CLIP-1587:  Fix the Invalid apiVersion problem

### DIFF
--- a/.github/workflows/e2e-test-no-domain.yaml
+++ b/.github/workflows/e2e-test-no-domain.yaml
@@ -65,8 +65,6 @@ jobs:
         working-directory: test/
         run: |
           set -o pipefail
-          aws --version
-          kubectl version --short
           go test ./e2etest -v -timeout 85m -run Installer | tee ./e2etest/artifacts/e2etest.log
 
       - name: Upload test log files

--- a/.github/workflows/e2e-test-no-domain.yaml
+++ b/.github/workflows/e2e-test-no-domain.yaml
@@ -65,6 +65,8 @@ jobs:
         working-directory: test/
         run: |
           set -o pipefail
+          aws --version
+          kubectl version --short
           go test ./e2etest -v -timeout 85m -run Installer | tee ./e2etest/artifacts/e2etest.log
 
       - name: Upload test log files

--- a/.github/workflows/e2e-test-no-domain.yaml
+++ b/.github/workflows/e2e-test-no-domain.yaml
@@ -31,7 +31,7 @@ jobs:
       - name: Pin Kubectl version
         uses: azure/setup-kubectl@v2.0
         with:
-          version: 'v1.23.6'
+          version: 'v1.24.0'
 
       - name: Setup Go environment
         uses: actions/setup-go@v2.1.4

--- a/.github/workflows/e2e-test-with-domain.yaml
+++ b/.github/workflows/e2e-test-with-domain.yaml
@@ -31,7 +31,7 @@ jobs:
       - name: Pin Kubectl version
         uses: azure/setup-kubectl@v2.0
         with:
-          version: 'v1.23.6'
+          version: 'v1.24.0'
 
       - name: Setup Go environment
         uses: actions/setup-go@v2.1.4

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
 # Change Log
 
+## 2.0.2
+
+**Release date:** 2022-06-30
+
+* Upgraded Helm chart version to 1.4.0
 * Using v1beta1 apiVersion for client.authentication.k8s.io
+
 
 ## 2.0.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Change Log
 
+* Using v1beta1 apiVersion for client.authentication.k8s.io
+
 ## 2.0.1
 
 **Release date:** 2022-05-18

--- a/config.tfvars
+++ b/config.tfvars
@@ -46,7 +46,7 @@ max_cluster_capacity = 5
 ################################################################################
 
 # Helm chart version of Jira
-jira_helm_chart_version = "1.3.0"
+jira_helm_chart_version = "1.4.0"
 
 # Number of Jira application nodes
 # Note: For initial installation this value needs to be set to 1 and it can be changed only after Jira is fully
@@ -125,7 +125,7 @@ jira_db_name = "jira"
 ################################################################################
 
 # Helm chart version of Confluence
-confluence_helm_chart_version = "1.3.0"
+confluence_helm_chart_version = "1.4.0"
 
 # Number of Confluence application nodes
 # Note: For initial installation this value needs to be set to 1 and it can be changed only after Confluence is fully
@@ -205,7 +205,7 @@ confluence_collaborative_editing_enabled = true
 ################################################################################
 
 # Helm chart version of Bitbucket
-bitbucket_helm_chart_version = "1.3.0"
+bitbucket_helm_chart_version = "1.4.0"
 
 # Number of Bitbucket application nodes
 bitbucket_replica_count = 1
@@ -304,8 +304,8 @@ bitbucket_db_name = "bitbucket"
 ################################################################################
 
 # Helm chart version of Bamboo and Bamboo agent instances
-bamboo_helm_chart_version       = "1.3.0"
-bamboo_agent_helm_chart_version = "1.3.0"
+bamboo_helm_chart_version       = "1.4.0"
+bamboo_agent_helm_chart_version = "1.4.0"
 
 # By default, Bamboo and the Bamboo Agent will use the versions defined in their respective Helm charts:
 # https://github.com/atlassian/data-center-helm-charts/blob/main/src/main/charts/bamboo/Chart.yaml

--- a/docs/docs/userguide/PREREQUISITES.md
+++ b/docs/docs/userguide/PREREQUISITES.md
@@ -8,7 +8,7 @@ Its advised that the tooling below is installed to your development environment.
 
 1. [Terraform](#terraform) 
 2. [Helm v3.3 or later](#helm)
-3. [AWS CLI](#aws-cli)
+3. [AWS CLI v2.7 or later](#aws-cli)
 4. [Kubectl](#kubectl) (optional)
 5. [Kubernetes cluster monitoring tools](#kubernetes-cluster-monitoring-tools) (optional)
 

--- a/install.sh
+++ b/install.sh
@@ -223,6 +223,9 @@ set_current_context_k8s() {
     if [ -z "${FORCE_FLAG}" ]; then
       aws --region "${REGION}" eks update-kubeconfig --name "${EKS_CLUSTER}"
     fi
+    # e2e test uses context file to connect to k8s and since aws-iam-authenticator 0.5.5 is using v1beta1 api version
+    # for authentication, then we need to switch to v1beta1
+    sed 's/client.authentication.k8s.io\/v1alpha1/client.authentication.k8s.io\/v1beta1/g' "${CONTEXT_FILE}" > tmp && mv tmp "${CONTEXT_FILE}"
   else
     log "Kubernetes context file '${CONTEXT_FILE}' could not be found."
   fi

--- a/providers.tf
+++ b/providers.tf
@@ -13,7 +13,7 @@ provider "kubernetes" {
   cluster_ca_certificate = module.base-infrastructure.eks.kubernetes_provider_config.cluster_ca_certificate
   exec {
     api_version = "client.authentication.k8s.io/v1beta1"
-    args        = ["eks", "get-token", "--cluster-name", local.cluster_name]
+    args        = ["eks", "get-token", "--cluster-name", local.cluster_name, "--api-version", "v1beta1"]
     command     = "aws"
   }
 }
@@ -24,7 +24,7 @@ provider "helm" {
     cluster_ca_certificate = module.base-infrastructure.eks.kubernetes_provider_config.cluster_ca_certificate
     exec {
       api_version = "client.authentication.k8s.io/v1beta1"
-      args        = ["eks", "get-token", "--cluster-name", local.cluster_name]
+      args        = ["eks", "get-token", "--cluster-name", local.cluster_name, "--api-version", "v1beta1"]
       command     = "aws"
     }
   }

--- a/providers.tf
+++ b/providers.tf
@@ -12,7 +12,7 @@ provider "kubernetes" {
   host                   = module.base-infrastructure.eks.kubernetes_provider_config.host
   cluster_ca_certificate = module.base-infrastructure.eks.kubernetes_provider_config.cluster_ca_certificate
   exec {
-    api_version = "client.authentication.k8s.io/v1alpha1"
+    api_version = "client.authentication.k8s.io/v1beta1"
     args        = ["eks", "get-token", "--cluster-name", local.cluster_name]
     command     = "aws"
   }
@@ -23,7 +23,7 @@ provider "helm" {
     host                   = module.base-infrastructure.eks.kubernetes_provider_config.host
     cluster_ca_certificate = module.base-infrastructure.eks.kubernetes_provider_config.cluster_ca_certificate
     exec {
-      api_version = "client.authentication.k8s.io/v1alpha1"
+      api_version = "client.authentication.k8s.io/v1beta1"
       args        = ["eks", "get-token", "--cluster-name", local.cluster_name]
       command     = "aws"
     }

--- a/providers.tf
+++ b/providers.tf
@@ -13,7 +13,7 @@ provider "kubernetes" {
   cluster_ca_certificate = module.base-infrastructure.eks.kubernetes_provider_config.cluster_ca_certificate
   exec {
     api_version = "client.authentication.k8s.io/v1beta1"
-    args        = ["eks", "get-token", "--cluster-name", local.cluster_name, "--api-version", "v1beta1"]
+    args        = ["eks", "get-token", "--cluster-name", local.cluster_name]
     command     = "aws"
   }
 }
@@ -24,7 +24,7 @@ provider "helm" {
     cluster_ca_certificate = module.base-infrastructure.eks.kubernetes_provider_config.cluster_ca_certificate
     exec {
       api_version = "client.authentication.k8s.io/v1beta1"
-      args        = ["eks", "get-token", "--cluster-name", local.cluster_name, "--api-version", "v1beta1"]
+      args        = ["eks", "get-token", "--cluster-name", local.cluster_name]
       command     = "aws"
     }
   }

--- a/test/e2etest/bitbucket_test.go
+++ b/test/e2etest/bitbucket_test.go
@@ -10,7 +10,7 @@ import (
 	"strings"
 	"testing"
 
-    "github.com/go-git/go-git/v5"
+	"github.com/go-git/go-git/v5"
 	"github.com/go-git/go-git/v5/plumbing/transport/ssh"
 	"github.com/gruntwork-io/terratest/modules/k8s"
 	"github.com/stretchr/testify/assert"
@@ -44,11 +44,7 @@ func assertBitbucketNfsConnectivity(t *testing.T, testConfig TestConfig) {
 		"-c", "echo \"Greetings from an NFS\" >> $(find /srv/nfs/ | head -1)/nfs-file-share-test.txt; echo $?")
 
 	assert.Nil(t, kubectlError)
-	// Due to the deprecation of v1alpha1, there will be an extra line added to kubectl output:
-	// Kubeconfig user entry is using deprecated API version client.authentication.k8s.io/v1alpha1. Run 'aws eks update-kubeconfig' to update.\n0
-	outputSlice := strings.Split(output, "\n")
-	returnCode := outputSlice[1]
-	assert.Equal(t, "0", returnCode)
+	assert.Equal(t, "0", output)
 
 	// Read the file from the Bitbucket pod
 	output, kubectlError = k8s.RunKubectlAndGetOutputE(t, kubectlOptions,
@@ -58,11 +54,7 @@ func assertBitbucketNfsConnectivity(t *testing.T, testConfig TestConfig) {
 		"-c", "cat /var/atlassian/application-data/shared-home/nfs-file-share-test.txt")
 
 	assert.Nil(t, kubectlError)
-	// Due to the deprecation of v1alpha1, there will be an extra line added to kubectl output:
-	// Kubeconfig user entry is using deprecated API version client.authentication.k8s.io/v1alpha1. Run 'aws eks update-kubeconfig' to update.\nGreetings from an NFS
-	outputSlice = strings.Split(output, "\n")
-	fileContents := outputSlice[1]
-	assert.Equal(t, "Greetings from an NFS", fileContents)
+	assert.Equal(t, "Greetings from an NFS", output)
 }
 
 func assertBitbucketSshConnectivity(t *testing.T, testConfig TestConfig, productUrl string) {

--- a/test/unittest/test_variables.go
+++ b/test/unittest/test_variables.go
@@ -271,7 +271,7 @@ var BitbucketInvalidVariables = map[string]interface{}{
 	"replica_count":        1,
 	"installation_timeout": invalidTestTimeout,
 	"bitbucket_configuration": map[string]interface{}{
-		"helm_version": "1.3.0",
+		"helm_version": "1.4.0",
 		"cpu":          "1",
 		"mem":          "1Gi",
 		"min_heap":     "256m",

--- a/variables.tf
+++ b/variables.tf
@@ -108,7 +108,7 @@ variable "logging_bucket" {
 variable "jira_helm_chart_version" {
   description = "Version of Jira Helm chart"
   type        = string
-  default     = "1.3.0"
+  default     = "1.4.0"
 }
 
 variable "jira_image_repository" {
@@ -293,7 +293,7 @@ variable "confluence_license" {
 variable "confluence_helm_chart_version" {
   description = "Version of confluence Helm chart"
   type        = string
-  default     = "1.3.0"
+  default     = "1.4.0"
 }
 
 variable "confluence_version_tag" {
@@ -457,7 +457,7 @@ variable "confluence_shared_home_snapshot_id" {
 variable "bitbucket_helm_chart_version" {
   description = "Version of Bitbucket Helm chart"
   type        = string
-  default     = "1.3.0"
+  default     = "1.4.0"
 }
 
 variable "bitbucket_version_tag" {
@@ -726,14 +726,14 @@ variable "number_of_bamboo_agents" {
 
 variable "bamboo_helm_chart_version" {
   description = "Version of Bamboo Helm chart"
-  default     = "1.3.0"
+  default     = "1.4.0"
   type        = string
 }
 
 variable "bamboo_agent_helm_chart_version" {
   description = "Version of Bamboo agent Helm chart"
   type        = string
-  default     = "1.3.0"
+  default     = "1.4.0"
 }
 
 variable "bamboo_version_tag" {


### PR DESCRIPTION
## Pull request description
`aws-iam-authenticator v0.5.5` require `v1beta1` apiVersion for k8s authentication client (replacing `client.authentication.k8s.io/v1alpha1` with `client.authentication.k8s.io/v1beta1` ). 
This caused a failure in provisioning the DC product using terraform project. 

The problem is reported by `dc-app` team and this PR is addressing it by switching the apiVersion to the client.authentication.k8s.io/v1beta1 and right aws cli and Kubernetes version. 

## Checklist
- [x] I have successful end to end tests run (with & without domain)
- [x] I have added unit tests (if applicable)
- [x] I have user documentation (if applicable)
