### PR TITLE
CLIP-1588: Schedule to run end to end tests on every second day early morning

### DIFF
--- a/.github/workflows/e2e-test-no-domain.yaml
+++ b/.github/workflows/e2e-test-no-domain.yaml
@@ -1,5 +1,7 @@
 name: E2E Testing with no domain
 on:
+  schedule:
+    - cron: '0 1 * * 1' # schedule the test to run every Monday at 1:00am
   push:
     branches:
       - main

--- a/.github/workflows/e2e-test-no-domain.yaml
+++ b/.github/workflows/e2e-test-no-domain.yaml
@@ -1,7 +1,7 @@
 name: E2E Testing with no domain
 on:
   schedule:
-    - cron: '0 1 * * 1' # schedule the test to run every Monday at 1:00am
+    - cron: '0 1 */2 * *' # schedule the test to run every second day at 1:00am
   push:
     branches:
       - main

--- a/.github/workflows/e2e-test-with-domain.yaml
+++ b/.github/workflows/e2e-test-with-domain.yaml
@@ -1,7 +1,7 @@
 name: E2E Testing with domain
 on:
   schedule:
-    - cron: '0 2 */2 * *' # schedule the test to run every Monday at 2:00am
+    - cron: '0 2 */2 * *' # schedule the test to run every second day at 2:00am
   push:
     branches:
       - main

--- a/.github/workflows/e2e-test-with-domain.yaml
+++ b/.github/workflows/e2e-test-with-domain.yaml
@@ -1,7 +1,7 @@
 name: E2E Testing with domain
 on:
   schedule:
-    - cron: '0 2 * * 1' # schedule the test to run every Monday at 2:00am
+    - cron: '0 2 */2 * *' # schedule the test to run every Monday at 2:00am
   push:
     branches:
       - main

--- a/.github/workflows/e2e-test-with-domain.yaml
+++ b/.github/workflows/e2e-test-with-domain.yaml
@@ -1,5 +1,7 @@
 name: E2E Testing with domain
 on:
+  schedule:
+    - cron: '0 2 * * 1' # schedule the test to run every Monday at 2:00am
   push:
     branches:
       - main


### PR DESCRIPTION
## Pull request description

We didn't have scheduled the end to end tests run and in no active development periods, we never find out about test failures. To give more visibility on the health of the repo we should run e2e tests in a logical period of time. 

As there is no frequent change in this repo, and e2e test is an expensive test, testing in every second day basis would be sufficient to keep an eye on the repo health and in the same time not spend much on heavy test process. 

## Checklist
- [-] I have successful end to end tests run (with & without domain)
- [x] I have added unit tests (if applicable)
- [x] I have user documentation (if applicable)
