### PR TITLE
CLIP-1627: Update the default Helm chart version to 1.5.0 for all products

### DIFF
--- a/config.tfvars
+++ b/config.tfvars
@@ -58,7 +58,7 @@ max_cluster_capacity = 5
 ################################################################################
 
 # Helm chart version of Jira
-jira_helm_chart_version = "1.4.0"
+jira_helm_chart_version = "1.5.0"
 
 # Number of Jira application nodes
 # Note: For initial installation this value needs to be set to 1 and it can be changed only after Jira is fully
@@ -137,7 +137,7 @@ jira_db_name = "jira"
 ################################################################################
 
 # Helm chart version of Confluence
-confluence_helm_chart_version = "1.4.0"
+confluence_helm_chart_version = "1.5.0"
 
 # Number of Confluence application nodes
 # Note: For initial installation this value needs to be set to 1 and it can be changed only after Confluence is fully
@@ -217,7 +217,7 @@ confluence_collaborative_editing_enabled = true
 ################################################################################
 
 # Helm chart version of Bitbucket
-bitbucket_helm_chart_version = "1.4.0"
+bitbucket_helm_chart_version = "1.5.0"
 
 # Number of Bitbucket application nodes
 bitbucket_replica_count = 1
@@ -316,8 +316,8 @@ bitbucket_db_name = "bitbucket"
 ################################################################################
 
 # Helm chart version of Bamboo and Bamboo agent instances
-bamboo_helm_chart_version       = "1.4.0"
-bamboo_agent_helm_chart_version = "1.4.0"
+bamboo_helm_chart_version       = "1.5.0"
+bamboo_agent_helm_chart_version = "1.5.0"
 
 # By default, Bamboo and the Bamboo Agent will use the versions defined in their respective Helm charts:
 # https://github.com/atlassian/data-center-helm-charts/blob/main/src/main/charts/bamboo/Chart.yaml

--- a/variables.tf
+++ b/variables.tf
@@ -114,7 +114,7 @@ variable "eks_additional_roles" {
 variable "jira_helm_chart_version" {
   description = "Version of Jira Helm chart"
   type        = string
-  default     = "1.4.0"
+  default     = "1.5.0"
 }
 
 variable "jira_image_repository" {
@@ -299,7 +299,7 @@ variable "confluence_license" {
 variable "confluence_helm_chart_version" {
   description = "Version of confluence Helm chart"
   type        = string
-  default     = "1.4.0"
+  default     = "1.5.0"
 }
 
 variable "confluence_version_tag" {
@@ -463,7 +463,7 @@ variable "confluence_shared_home_snapshot_id" {
 variable "bitbucket_helm_chart_version" {
   description = "Version of Bitbucket Helm chart"
   type        = string
-  default     = "1.4.0"
+  default     = "1.5.0"
 }
 
 variable "bitbucket_version_tag" {
@@ -732,14 +732,14 @@ variable "number_of_bamboo_agents" {
 
 variable "bamboo_helm_chart_version" {
   description = "Version of Bamboo Helm chart"
-  default     = "1.4.0"
+  default     = "1.5.0"
   type        = string
 }
 
 variable "bamboo_agent_helm_chart_version" {
   description = "Version of Bamboo agent Helm chart"
   type        = string
-  default     = "1.4.0"
+  default     = "1.5.0"
 }
 
 variable "bamboo_version_tag" {


### PR DESCRIPTION
## Pull request description

As we have Helm chart 1.5.0 released for all products, so we should update the default chart versions in terraform solution.  

## Checklist
- [ ] I have successful end to end tests run (with & without domain)
- [ ] I have added unit tests (if applicable)
- [ ] I have user documentation (if applicable)
