### PR TITLE
CLIP-1631: Fix terraform e2e test with no domain 

### DIFF
--- a/config.tfvars
+++ b/config.tfvars
@@ -142,7 +142,7 @@ jira_db_name = "jira"
 ################################################################################
 
 # Helm chart version of Confluence
-confluence_helm_chart_version = "1.5.0"
+confluence_helm_chart_version = "1.4.0"
 
 # Number of Confluence application nodes
 # Note: For initial installation this value needs to be set to 1 and it can be changed only after Confluence is fully

--- a/test/e2etest/test-config.tfvars.tmpl
+++ b/test/e2etest/test-config.tfvars.tmpl
@@ -99,6 +99,9 @@ jira_db_name                 = "jira"
 confluence_license                 = "{{.confluence_license}}"
 confluence_db_name                 = "confluence"
 
+# For test purpose
+confluence_helm_chart_version  = "1.5.0"
+
 confluence_nfs_requests_cpu    = "0.25"
 confluence_nfs_requests_memory = "256Mi"
 confluence_nfs_limits_cpu      = "0.25"

--- a/test/e2etest/test-config.tfvars.tmpl
+++ b/test/e2etest/test-config.tfvars.tmpl
@@ -99,9 +99,6 @@ jira_db_name                 = "jira"
 confluence_license                 = "{{.confluence_license}}"
 confluence_db_name                 = "confluence"
 
-# For test purpose
-confluence_helm_chart_version  = "1.4.0"
-
 confluence_nfs_requests_cpu    = "0.25"
 confluence_nfs_requests_memory = "256Mi"
 confluence_nfs_limits_cpu      = "0.25"

--- a/test/e2etest/test-config.tfvars.tmpl
+++ b/test/e2etest/test-config.tfvars.tmpl
@@ -100,7 +100,7 @@ confluence_license                 = "{{.confluence_license}}"
 confluence_db_name                 = "confluence"
 
 # For test purpose
-confluence_helm_chart_version  = "1.5.0"
+confluence_helm_chart_version  = "1.4.0"
 
 confluence_nfs_requests_cpu    = "0.25"
 confluence_nfs_requests_memory = "256Mi"

--- a/variables.tf
+++ b/variables.tf
@@ -116,7 +116,7 @@ variable "whitelist_cidr" {
     for o in var.whitelist_cidr : can(regex("^(([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\\.){3}([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])/([0-9]|1[0-9]|2[0-9]|3[0-2])$", o))])
     error_message = "Invalid whitelist CIDR. Valid format is a list of '<IPv4>/[0-32]' e.g: [\"10.0.0.0/18\"]."
   }
-} 
+}
 
 ################################################################################
 # Jira Settings
@@ -310,7 +310,7 @@ variable "confluence_license" {
 variable "confluence_helm_chart_version" {
   description = "Version of confluence Helm chart"
   type        = string
-  default     = "1.5.0"
+  default     = "1.4.0"
 }
 
 variable "confluence_version_tag" {


### PR DESCRIPTION
## Pull request description

The test fails on installing Confluence Helm chart. Test passes with Confluence Helm chart `1.4.0` but fails with `1.5.0`. I revert the confluence helm chart version to `1.4.0` and create a separated ticket (CLIP-1632) to address this issue in Helm chart repo. 

## Checklist
- [ ] I have successful end to end tests run (with & without domain)
- [ ] I have added unit tests (if applicable)
- [ ] I have user documentation (if applicable)
