### PR TITLE
CLIP-1635: Release data-center-terraform 2.0.4

### DIFF
--- a/docs/docs/userguide/INSTALLATION.md
+++ b/docs/docs/userguide/INSTALLATION.md
@@ -11,7 +11,7 @@ Set up a user with an administrator IAM role. See [Configuration basics — AWS 
 Clone the `data-center-terraform` project repository from GitHub:
 
 ```shell
-git clone -b 2.0 https://github.com/atlassian-labs/data-center-terraform.git && cd data-center-terraform
+git clone -b 2.0.4 https://github.com/atlassian-labs/data-center-terraform.git && cd data-center-terraform
 ```
 
 ## 3. Configure the infrastructure

--- a/docs/docs/userguide/INSTALLATION.md
+++ b/docs/docs/userguide/INSTALLATION.md
@@ -11,7 +11,7 @@ Set up a user with an administrator IAM role. See [Configuration basics — AWS 
 Clone the `data-center-terraform` project repository from GitHub:
 
 ```shell
-git clone -b 2.0.3 https://github.com/atlassian-labs/data-center-terraform.git && cd data-center-terraform
+git clone -b 2.0 https://github.com/atlassian-labs/data-center-terraform.git && cd data-center-terraform
 ```
 
 ## 3. Configure the infrastructure


### PR DESCRIPTION
## Pull request description

E2e tests using this solution to provision the infrastructure and run the applications. That was failing because of the Go version. This problem is now fixed. As Helm chart uses the latest release of terraform solution in e2e test, we need to make a new release to the latest changes pick by the e2e test. 

## Checklist
- [ ] I have successful end to end tests run (with & without domain)
- [ ] I have added unit tests (if applicable)
- [x] I have user documentation (if applicable)
