### PR TITLE
CLIP-1656: Override termination graceful period

### DIFF
--- a/config.tfvars
+++ b/config.tfvars
@@ -75,6 +75,12 @@ jira_replica_count = 1
 # can be dataset restoration, resource requirements, number of replicas and others.
 #jira_installation_timeout = <MINUTES>
 
+# Termination grace period
+# Under certain conditions, pods may be stuck in a Terminating state which forces shared-home pvc to be stuck
+# in Terminating too causing Terraform destroy error (timing out waiting for a deleted PVC). Set termination graceful period to 0
+# if you encounter such an issue
+#jira_termination_grace_period = 0
+
 # By default, Jira Software will use the version defined in the Helm chart. If you wish to override the version, uncomment
 # the following line and set the jira_version_tag to any of the versions available on https://hub.docker.com/r/atlassian/jira-software/tags
 #jira_version_tag = "<JIRA_VERSION_TAG>"
@@ -154,6 +160,12 @@ confluence_replica_count = 1
 # can be dataset restoration, resource requirements, number of replicas and others.
 #confluence_installation_timeout = <MINUTES>
 
+# Termination grace period
+# Under certain conditions, pods may be stuck in a Terminating state which forces shared-home pvc to be stuck
+# in Terminating too causing Terraform destroy error (timing out waiting for a deleted PVC). Set termination graceful period to 0
+# if you encounter such an issue.
+# confluence_termination_grace_period = 0
+
 # By default, Confluence will use the version defined in the Helm chart. If you wish to override the version, uncomment
 # the following line and set the confluence_version_tag to any of the versions available on https://hub.docker.com/r/atlassian/confluence/tags
 #confluence_version_tag = "<CONFLUENCE_VERSION_TAG>"
@@ -232,8 +244,14 @@ bitbucket_replica_count = 1
 # can be dataset restoration, resource requirements, number of replicas and others.
 #bitbucket_installation_timeout = <MINUTES>
 
+# Termination grace period
+# Under certain conditions, pods may be stuck in a Terminating state which forces shared-home pvc to be stuck
+# in Terminating too causing Terraform destroy error (timing out waiting for a deleted PVC). Set termination graceful period to 0
+# if you encounter such an issue
+#bitbucket_termination_grace_period = 0
+
 # By default, Bitbucket will use the version defined in the Bitbucket Helm chart:
-# https://github.com/atlassian/data-center-helm-charts/blob/main/src/main/charts/bitbucket/Chart.yaml 
+# https://github.com/atlassian/data-center-helm-charts/blob/main/src/main/charts/bitbucket/Chart.yaml
 # If you wish to override the version, uncomment the following line and set the bitbucket_version_tag to any of the versions published for Bitbucket on Docker Hub: https://hub.docker.com/r/atlassian/bitbucket/tags
 #bitbucket_version_tag = "<BITBUCKET_VERSION_TAG>"
 
@@ -328,7 +346,7 @@ bamboo_agent_helm_chart_version = "1.5.0"
 # https://github.com/atlassian/data-center-helm-charts/blob/main/src/main/charts/bamboo/Chart.yaml
 # https://github.com/atlassian/data-center-helm-charts/blob/main/src/main/charts/bamboo-agent/Chart.yaml
 # If you wish to override these versions, uncomment the following lines and set the bamboo_version_tag and bamboo_agent_version_tag to any of the versions published on Docker Hub:
-# https://hub.docker.com/r/atlassian/bamboo/tags 
+# https://hub.docker.com/r/atlassian/bamboo/tags
 # https://hub.docker.com/r/atlassian/bamboo-agent-base/tags
 #bamboo_version_tag       = "<BAMBOO_VERSION_TAG>"
 #bamboo_agent_version_tag = "<BAMBOO_AGENT_VERSION_TAG>"
@@ -399,3 +417,9 @@ bamboo_db_name                 = "bamboo"
 # See https://developer.atlassian.com/platform/marketplace/dc-apps-performance-toolkit-user-guide-bamboo
 #
 #dataset_url = "https://centaurus-datasets.s3.amazonaws.com/bamboo/dcapt-bamboo.zip"
+
+# Termination grace period
+# Under certain conditions, pods may be stuck in a Terminating state which forces shared-home pvc to be stuck
+# in Terminating too causing Terraform destroy error (timing out waiting for a deleted PVC). Set termination graceful period to 0
+# if you encounter such an issue. This will apply to both Bamboo server and agent pods.
+#bamboo_termination_grace_period = 0

--- a/dc-infrastructure.tf
+++ b/dc-infrastructure.tf
@@ -43,6 +43,7 @@ module "bamboo" {
   }
 
   installation_timeout = var.bamboo_installation_timeout
+  termination_grace_period  = var.bamboo_termination_grace_period
 
   bamboo_configuration = {
     helm_version = var.bamboo_helm_chart_version
@@ -96,8 +97,9 @@ module "jira" {
   db_master_username      = var.jira_db_master_username
   db_master_password      = var.jira_db_master_password
 
-  replica_count        = var.jira_replica_count
-  installation_timeout = var.jira_installation_timeout
+  replica_count             = var.jira_replica_count
+  installation_timeout      = var.jira_installation_timeout
+  termination_grace_period  = var.jira_termination_grace_period
 
   jira_configuration = {
     helm_version        = var.jira_helm_chart_version
@@ -146,10 +148,11 @@ module "confluence" {
   db_master_username       = var.confluence_db_master_username
   db_master_password       = var.confluence_db_master_password
 
-  replica_count        = var.confluence_replica_count
-  installation_timeout = var.confluence_installation_timeout
-  version_tag          = var.confluence_version_tag
-  enable_synchrony     = var.confluence_collaborative_editing_enabled
+  replica_count             = var.confluence_replica_count
+  installation_timeout      = var.confluence_installation_timeout
+  version_tag               = var.confluence_version_tag
+  enable_synchrony          = var.confluence_collaborative_editing_enabled
+  termination_grace_period  = var.confluence_termination_grace_period
 
   confluence_configuration = {
     helm_version = var.confluence_helm_chart_version
@@ -193,8 +196,9 @@ module "bitbucket" {
   db_master_username      = var.bitbucket_db_master_username
   db_master_password      = var.bitbucket_db_master_password
 
-  replica_count        = var.bitbucket_replica_count
-  installation_timeout = var.bitbucket_installation_timeout
+  replica_count             = var.bitbucket_replica_count
+  installation_timeout      = var.bitbucket_installation_timeout
+  termination_grace_period  = var.bitbucket_termination_grace_period
 
   bitbucket_configuration = {
     helm_version = var.bitbucket_helm_chart_version

--- a/modules/products/bamboo/helm.tf
+++ b/modules/products/bamboo/helm.tf
@@ -12,6 +12,9 @@ resource "helm_release" "bamboo" {
   values = [
     yamlencode({
       bamboo = {
+        shutdown = {
+          terminationGracePeriodSeconds = var.termination_grace_period
+        }
         resources = {
           jvm = {
             maxHeap = local.bamboo_software_resources.maxHeap
@@ -87,6 +90,9 @@ resource "helm_release" "bamboo_agent" {
     yamlencode({
       replicaCount = local.number_of_agents
       agent = {
+        shutdown = {
+          terminationGracePeriodSeconds = var.termination_grace_period
+        }
         securityToken = {
           secretName = kubernetes_secret.security_token_secret.metadata[0].name
         }

--- a/modules/products/bamboo/variables.tf
+++ b/modules/products/bamboo/variables.tf
@@ -50,7 +50,7 @@ variable "termination_grace_period" {
   description = "Termination grace period in seconds"
   type        = number
   validation {
-    condition     = var.termination_grace_period > 0
+    condition     = var.termination_grace_period >= 0
     error_message = "Termination grace period needs to be a positive number."
   }
 }

--- a/modules/products/bamboo/variables.tf
+++ b/modules/products/bamboo/variables.tf
@@ -49,7 +49,10 @@ variable "installation_timeout" {
 variable "termination_grace_period" {
   description = "Termination grace period in seconds"
   type        = number
-  default     = 30
+  validation {
+    condition     = var.termination_grace_period > 0
+    error_message = "Termination grace period needs to be a positive number."
+  }
 }
 
 variable "bamboo_configuration" {

--- a/modules/products/bamboo/variables.tf
+++ b/modules/products/bamboo/variables.tf
@@ -46,6 +46,12 @@ variable "installation_timeout" {
   }
 }
 
+variable "termination_grace_period" {
+  description = "Termination grace period in seconds"
+  type        = number
+  default     = 30
+}
+
 variable "bamboo_configuration" {
   description = "Bamboo resource spec and chart version"
   type        = map(any)

--- a/modules/products/bitbucket/helm.tf
+++ b/modules/products/bitbucket/helm.tf
@@ -13,6 +13,9 @@ resource "helm_release" "bitbucket" {
     yamlencode({
       replicaCount = var.replica_count,
       bitbucket = {
+        shutdown = {
+          terminationGracePeriodSeconds = var.termination_grace_period
+        }
         clustering = {
           enabled = true
         }

--- a/modules/products/bitbucket/variables.tf
+++ b/modules/products/bitbucket/variables.tf
@@ -57,6 +57,12 @@ variable "replica_count" {
   type        = number
 }
 
+variable "termination_grace_period" {
+  description = "Termination grace period in seconds"
+  type        = number
+  default     = 30
+}
+
 variable "installation_timeout" {
   description = "Timeout for helm chart installation in minutes"
   type        = number

--- a/modules/products/bitbucket/variables.tf
+++ b/modules/products/bitbucket/variables.tf
@@ -60,7 +60,10 @@ variable "replica_count" {
 variable "termination_grace_period" {
   description = "Termination grace period in seconds"
   type        = number
-  default     = 30
+  validation {
+    condition     = var.termination_grace_period > 0
+    error_message = "Termination grace period needs to be a positive number."
+  }
 }
 
 variable "installation_timeout" {

--- a/modules/products/bitbucket/variables.tf
+++ b/modules/products/bitbucket/variables.tf
@@ -61,7 +61,7 @@ variable "termination_grace_period" {
   description = "Termination grace period in seconds"
   type        = number
   validation {
-    condition     = var.termination_grace_period > 0
+    condition     = var.termination_grace_period >= 0
     error_message = "Termination grace period needs to be a positive number."
   }
 }

--- a/modules/products/confluence/helm.tf
+++ b/modules/products/confluence/helm.tf
@@ -14,6 +14,9 @@ resource "helm_release" "confluence" {
     yamlencode({
       replicaCount = var.replica_count,
       confluence = {
+        shutdown = {
+          terminationGracePeriodSeconds = var.termination_grace_period
+        }
         clustering = {
           enabled = true
         }

--- a/modules/products/confluence/variables.tf
+++ b/modules/products/confluence/variables.tf
@@ -51,6 +51,12 @@ variable "replica_count" {
   type        = number
 }
 
+variable "termination_grace_period" {
+  description = "Termination grace period in seconds"
+  type        = number
+  default     = 30
+}
+
 variable "installation_timeout" {
   description = "Timeout for helm chart installation in minutes"
   type        = number

--- a/modules/products/confluence/variables.tf
+++ b/modules/products/confluence/variables.tf
@@ -54,7 +54,10 @@ variable "replica_count" {
 variable "termination_grace_period" {
   description = "Termination grace period in seconds"
   type        = number
-  default     = 30
+  validation {
+    condition     = var.termination_grace_period > 0
+    error_message = "Termination grace period needs to be a positive number."
+  }
 }
 
 variable "installation_timeout" {

--- a/modules/products/confluence/variables.tf
+++ b/modules/products/confluence/variables.tf
@@ -55,7 +55,7 @@ variable "termination_grace_period" {
   description = "Termination grace period in seconds"
   type        = number
   validation {
-    condition     = var.termination_grace_period > 0
+    condition     = var.termination_grace_period >= 0
     error_message = "Termination grace period needs to be a positive number."
   }
 }

--- a/modules/products/jira/helm.tf
+++ b/modules/products/jira/helm.tf
@@ -16,6 +16,9 @@ resource "helm_release" "jira" {
         repository = var.image_repository
       }
       jira = {
+        shutdown = {
+          terminationGracePeriodSeconds = var.termination_grace_period
+        }
         clustering = {
           enabled = true
         }

--- a/modules/products/jira/variables.tf
+++ b/modules/products/jira/variables.tf
@@ -57,7 +57,7 @@ variable "replica_count" {
   type        = number
 }
 
-variable "confluence_termination_grace_period" {
+variable "termination_grace_period" {
   description = "Termination grace period in seconds"
   type        = number
   default     = 30

--- a/modules/products/jira/variables.tf
+++ b/modules/products/jira/variables.tf
@@ -57,6 +57,12 @@ variable "replica_count" {
   type        = number
 }
 
+variable "confluence_termination_grace_period" {
+  description = "Termination grace period in seconds"
+  type        = number
+  default     = 30
+}
+
 variable "installation_timeout" {
   description = "Timeout for helm chart installation in minutes"
   type        = number

--- a/modules/products/jira/variables.tf
+++ b/modules/products/jira/variables.tf
@@ -60,7 +60,10 @@ variable "replica_count" {
 variable "termination_grace_period" {
   description = "Termination grace period in seconds"
   type        = number
-  default     = 30
+  validation {
+    condition     = var.termination_grace_period > 0
+    error_message = "Termination grace period needs to be a positive number."
+  }
 }
 
 variable "installation_timeout" {

--- a/modules/products/jira/variables.tf
+++ b/modules/products/jira/variables.tf
@@ -61,7 +61,7 @@ variable "termination_grace_period" {
   description = "Termination grace period in seconds"
   type        = number
   validation {
-    condition     = var.termination_grace_period > 0
+    condition     = var.termination_grace_period >= 0
     error_message = "Termination grace period needs to be a positive number."
   }
 }

--- a/test/unittest/bamboo_test.go
+++ b/test/unittest/bamboo_test.go
@@ -154,4 +154,5 @@ var BambooIncorrectVariables = map[string]interface{}{
 		"agent_count":  5,
 		"invalid":      "value",
 	},
+	"termination_grace_period": 0,
 }

--- a/test/unittest/bamboo_test.go
+++ b/test/unittest/bamboo_test.go
@@ -99,6 +99,7 @@ var BambooCorrectVariables = map[string]interface{}{
 		"mem":          "1Gi",
 		"agent_count":  5,
 	},
+	"termination_grace_period": 0,
 }
 
 var BambooIncorrectVariables = map[string]interface{}{

--- a/test/unittest/bitbucket_test.go
+++ b/test/unittest/bitbucket_test.go
@@ -127,4 +127,5 @@ var BitbucketCorrectVariables = map[string]interface{}{
 	"elasticsearch_limits_memory":   "1Gi",
 	"elasticsearch_storage":         10,
 	"elasticsearch_replicas":        2,
+	"termination_grace_period":      0,
 }

--- a/test/unittest/confluence_test.go
+++ b/test/unittest/confluence_test.go
@@ -115,4 +115,5 @@ var ConfluenceCorrectVariables = map[string]interface{}{
 	"db_master_username":       "dummyUsername",
 	"db_master_password":       "dummyPassword!",
 	"db_snapshot_build_number": "1234",
+	 "termination_grace_period": 0,
 }

--- a/test/unittest/test_variables.go
+++ b/test/unittest/test_variables.go
@@ -311,6 +311,7 @@ var BitbucketInvalidVariables = map[string]interface{}{
 	"elasticsearch_limits_memory":   "1Gi",
 	"elasticsearch_storage":         10,
 	"elasticsearch_replicas":        9, // invalid, should be [2,8]
+	"termination_grace_period":      0,
 }
 
 var superLongStr = "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nam orci mauris, cursus sit amet tortor sit amet, aliquam dapibus magna. In sodales felis in ipsum euismod tempor. Phasellus mattis, justo id auctor lacinia, ipsum nulla sodales massa, ac porttitor arcu sem et quam."
@@ -360,6 +361,7 @@ var ConfluenceInvalidVariables = map[string]interface{}{
 	"db_snapshot_id":           "dummy-snapshot-id",
 	"db_master_password":       "dummyPassword!",
 	"db_snapshot_build_number": "invalid.build.number",
+	"termination_grace_period": 0,
 }
 
 // Jira
@@ -448,4 +450,6 @@ var JiraInvalidVariables = map[string]interface{}{
 	"db_master_password": "dummy_password",
 	"db_master_username": "dummy_username",
 	"db_snapshot_id":     "dummy-rds-snapshot-id",
+
+	"termination_grace_period": 0,
 }

--- a/test/unittest/test_variables.go
+++ b/test/unittest/test_variables.go
@@ -405,6 +405,8 @@ var JiraCorrectVariables = map[string]interface{}{
 	"db_master_password": "dummy_password",
 	"db_master_username": "dummy_username",
 	"db_snapshot_id":     "dummy-rds-snapshot-id",
+
+	"termination_grace_period": 0,
 }
 
 var JiraInvalidVariables = map[string]interface{}{

--- a/variables.tf
+++ b/variables.tf
@@ -150,6 +150,12 @@ variable "jira_replica_count" {
   }
 }
 
+variable "jira_termination_grace_period" {
+  description = "Termination grace period in seconds"
+  type        = number
+  default     = 30
+}
+
 variable "jira_installation_timeout" {
   description = "Timeout for helm chart installation in minutes"
   type        = number
@@ -329,6 +335,12 @@ variable "confluence_replica_count" {
   }
 }
 
+variable "confluence_termination_grace_period" {
+  description = "Termination grace period in seconds"
+  type        = number
+  default     = 30
+}
+
 variable "confluence_installation_timeout" {
   description = "Timeout for helm chart installation in minutes"
   type        = number
@@ -491,6 +503,12 @@ variable "bitbucket_replica_count" {
     condition     = var.bitbucket_replica_count >= 0
     error_message = "Number of nodes must be greater than or equal to 0."
   }
+}
+
+variable "bitbucket_termination_grace_period" {
+  description = "Termination grace period in seconds"
+  type        = number
+  default     = 30
 }
 
 variable "bitbucket_installation_timeout" {
@@ -763,6 +781,12 @@ variable "bamboo_installation_timeout" {
   description = "Timeout for helm chart installation in minutes"
   type        = number
   default     = 15
+}
+
+variable "bamboo_termination_grace_period" {
+  description = "Termination grace period in seconds"
+  type        = number
+  default     = 30
 }
 
 variable "bamboo_agent_version_tag" {


### PR DESCRIPTION
## Pull request description

Under certain conditions application pods are stuck in terminating when a Helm chart is deleted which blocks deletion of a shared home PVC. This results in a timeout error when running uninstall.sh. This PR makes termination grace period configurable in config var file which is passed to helm resource when it's being created. 

No unit tests since this part of pod spec is hidden in kube runtime which isn't available to Terraform.

## Checklist
- [x] I have successful end to end tests run (with & without domain)
