### PR TITLE
CLIP-1676: Release version 2.0.6.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Change Log
 
+## 2.0.6
+
+**Release date:** 2022-10-05
+
+* Fixed end-to-end test by skipping resuming Bamboo server if it's already running.
+* Added script to collecting k8s logs and events to help debugging 
+
 ## 2.0.5
 
 **Release date:** 2022-09-29

--- a/docs/docs/userguide/INSTALLATION.md
+++ b/docs/docs/userguide/INSTALLATION.md
@@ -11,7 +11,7 @@ Set up a user with an administrator IAM role. See [Configuration basics — AWS 
 Clone the `data-center-terraform` project repository from GitHub:
 
 ```shell
-git clone -b 2.0.5 https://github.com/atlassian-labs/data-center-terraform.git && cd data-center-terraform
+git clone -b 2.0.6 https://github.com/atlassian-labs/data-center-terraform.git && cd data-center-terraform
 ```
 
 ## 3. Configure the infrastructure

--- a/variables.tf
+++ b/variables.tf
@@ -316,7 +316,7 @@ variable "confluence_license" {
 variable "confluence_helm_chart_version" {
   description = "Version of confluence Helm chart"
   type        = string
-  default     = "1.4.0"
+  default     = "1.5.1"
 }
 
 variable "confluence_version_tag" {


### PR DESCRIPTION
## Pull request description

This PR is to release a new version of data-center-terraform.

CLIP-1676: Updated changelog and doc.
CLIP-1676: Updated default Confluence Helm chart version.

## Checklist
- [ ] I have successful end to end tests run (with & without domain)
- [ ] I have added unit tests (if applicable)
- [ ] I have user documentation (if applicable)
