### PR TITLE
CLIP-1674: Fix 'pvc still exists with finalizers' error during uninstallation

### DIFF
--- a/test/e2etest/test-config.tfvars.tmpl
+++ b/test/e2etest/test-config.tfvars.tmpl
@@ -64,6 +64,9 @@ number_of_bamboo_agents = 3
 # for details
 bamboo_dataset_url = "https://bamboo-test-datasets.s3.amazonaws.com/testing_dataset_minimal.zip"
 
+# To fix "pvc still exists with finalizers" error while uninstalling
+bamboo_termination_grace_period = 0
+
 ################################################################################
 # Jira Settings
 ################################################################################
@@ -92,6 +95,8 @@ jira_db_allocated_storage    = 100
 jira_db_iops                 = 1000
 jira_db_name                 = "jira"
 
+jira_termination_grace_period = 0
+
 ################################################################################
 # Confluence Settings
 ################################################################################
@@ -103,6 +108,8 @@ confluence_nfs_requests_cpu    = "0.25"
 confluence_nfs_requests_memory = "256Mi"
 confluence_nfs_limits_cpu      = "0.25"
 confluence_nfs_limits_memory   = "256Mi"
+
+confluence_termination_grace_period = 0
 
 ################################################################################
 # Bitbucket Settings
@@ -121,3 +128,5 @@ bitbucket_nfs_requests_cpu    = "0.25"
 bitbucket_nfs_requests_memory = "256Mi"
 bitbucket_nfs_limits_cpu      = "0.25"
 bitbucket_nfs_limits_memory   = "256Mi"
+
+bitbucket_termination_grace_period = 0


### PR DESCRIPTION
## Pull request description

Set product termination grace period to 0 to avoid 'pvc still exists with finalizers' error while uninstalling.

## Checklist
- [ ] I have successful end to end tests run (with & without domain)
- [ ] I have added unit tests (if applicable)
- [ ] I have user documentation (if applicable)
