### PR TITLE
Fix synchrony test

### DIFF
--- a/.github/workflows/e2e-test-no-domain.yaml
+++ b/.github/workflows/e2e-test-no-domain.yaml
@@ -32,8 +32,6 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v2
-        with:
-          ref: ${{ github.event.pull_request.head.sha }}
 
       - name: Pin Kubectl version
         uses: azure/setup-kubectl@v2.0

--- a/.github/workflows/e2e-test-no-domain.yaml
+++ b/.github/workflows/e2e-test-no-domain.yaml
@@ -32,6 +32,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v2
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
 
       - name: Pin Kubectl version
         uses: azure/setup-kubectl@v2.0

--- a/.github/workflows/e2e-test-with-domain.yaml
+++ b/.github/workflows/e2e-test-with-domain.yaml
@@ -32,7 +32,9 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v2
-        
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+
       - name: Pin Kubectl version
         uses: azure/setup-kubectl@v2.0
         with:

--- a/.github/workflows/e2e-test-with-domain.yaml
+++ b/.github/workflows/e2e-test-with-domain.yaml
@@ -32,9 +32,7 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v2
-        with:
-          ref: ${{ github.event.pull_request.head.sha }}
-
+    
       - name: Pin Kubectl version
         uses: azure/setup-kubectl@v2.0
         with:

--- a/.github/workflows/e2e-test-with-domain.yaml
+++ b/.github/workflows/e2e-test-with-domain.yaml
@@ -34,6 +34,7 @@ jobs:
         uses: actions/checkout@v2
         with:
           ref: ${{ github.event.pull_request.head.sha }}
+
       - name: Pin Kubectl version
         uses: azure/setup-kubectl@v2.0
         with:

--- a/config.tfvars
+++ b/config.tfvars
@@ -148,7 +148,7 @@ jira_db_name = "jira"
 ################################################################################
 
 # Helm chart version of Confluence
-confluence_helm_chart_version = "1.4.0"
+confluence_helm_chart_version = "1.5.1"
 
 # Number of Confluence application nodes
 # Note: For initial installation this value needs to be set to 1 and it can be changed only after Confluence is fully

--- a/modules/products/confluence/locals.tf
+++ b/modules/products/confluence/locals.tf
@@ -48,12 +48,11 @@ locals {
 
   confluence_ingress_url = local.domain_supplied ? "https://${local.product_domain_name}" : "http://${var.ingress.outputs.lb_hostname}/${local.product_name}"
 
-  synchrony_ingress_url = local.domain_supplied ? "${local.confluence_ingress_url}/synchrony" : "http://${var.ingress.outputs.lb_hostname}/${local.product_name}/synchrony"
+  synchrony_ingress_url = local.domain_supplied ? "${local.confluence_ingress_url}/synchrony" : "http://${var.ingress.outputs.lb_hostname}/synchrony"
 
   synchrony_settings_stanza = yamlencode({
     synchrony = {
       enabled    = true
-      ingressUrl = local.synchrony_ingress_url
     }
   })
 

--- a/test/e2etest/confluence_test.go
+++ b/test/e2etest/confluence_test.go
@@ -3,16 +3,15 @@ package e2etest
 import (
 	"fmt"
 	"github.com/stretchr/testify/assert"
-	"strings"
 	"testing"
 )
 
-func confluenceHealthTests(t *testing.T, productUrl string) {
+func confluenceHealthTests(t *testing.T, productUrl string, synchronyUrl string) {
 	printTestBanner(confluence, "Tests")
 
 	// Test Confluence and Synchrony status endpoints
 	assertConfluenceStatus(t, productUrl, "FIRST_RUN")
-	assertSynchronyStatus(t, productUrl, "OK")
+	assertSynchronyStatus(t, synchronyUrl, "OK")
 }
 
 func assertConfluenceStatus(t *testing.T, productUrl string, expectedStatus string) {
@@ -24,9 +23,7 @@ func assertConfluenceStatus(t *testing.T, productUrl string, expectedStatus stri
 }
 
 func assertSynchronyStatus(t *testing.T, productUrl string, expectedStatus string) {
-	statusUrl := "synchrony/heartbeat"
-	// trimming confluence from productUrl to have the correct synchrony URL
-	productUrl = strings.TrimSuffix(productUrl, "/confluence")
+	statusUrl := "heartbeat"
 	url := fmt.Sprintf("%s/%s", productUrl, statusUrl)
 	content := getPageContent(t, url)
 	println("Asserting Synchrony Status Endpoint...")

--- a/test/e2etest/confluence_test.go
+++ b/test/e2etest/confluence_test.go
@@ -3,6 +3,7 @@ package e2etest
 import (
 	"fmt"
 	"github.com/stretchr/testify/assert"
+	"strings"
 	"testing"
 )
 
@@ -24,6 +25,8 @@ func assertConfluenceStatus(t *testing.T, productUrl string, expectedStatus stri
 
 func assertSynchronyStatus(t *testing.T, productUrl string, expectedStatus string) {
 	statusUrl := "synchrony/heartbeat"
+	// trimming confluence from productUrl to have the correct synchrony URL
+	productUrl = strings.TrimSuffix(productUrl, "/confluence")
 	url := fmt.Sprintf("%s/%s", productUrl, statusUrl)
 	content := getPageContent(t, url)
 	println("Asserting Synchrony Status Endpoint...")

--- a/test/e2etest/installer_test.go
+++ b/test/e2etest/installer_test.go
@@ -30,6 +30,7 @@ func TestInstaller(t *testing.T) {
 	clusterHealthTests(t, testConfig)
 
 	productUrls := terraform.OutputMap(t, &terraform.Options{TerraformDir: "../../"}, "product_urls")
+	synchronyUrl := terraform.Output(t, &terraform.Options{TerraformDir: "../../"}, "synchrony_url")
 
 	if contains(productList, bamboo) {
 		bambooHealthTests(t, testConfig, productUrls[bamboo])
@@ -40,7 +41,7 @@ func TestInstaller(t *testing.T) {
 	}
 
 	if contains(productList, confluence) {
-		confluenceHealthTests(t, productUrls[confluence])
+		confluenceHealthTests(t, productUrls[confluence], synchronyUrl)
 	}
 
 	if contains(productList, bitbucket) {


### PR DESCRIPTION
Currently, synchrony tests are failing https://github.com/atlassian-labs/data-center-terraform/actions/runs/3201163413/jobs/5228854594

This happens because tests use the wrong synchrony url - it has /confluence in it while it should not https://github.com/atlassian/data-center-helm-charts/blob/main/src/main/charts/confluence/templates/ingress.yaml#L40

This PR trims `/confluence` suffix

## Checklist
- [x] I have successful end to end tests run (with & without domain)
- [x] I have added unit tests (if applicable)
- [ ] I have user documentation (if applicable)
