### PR TITLE
Run e2e against branches not only main branch

### DIFF
--- a/.github/workflows/e2e-test-no-domain.yaml
+++ b/.github/workflows/e2e-test-no-domain.yaml
@@ -32,6 +32,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v2
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
 
       - name: Pin Kubectl version
         uses: azure/setup-kubectl@v2.0

--- a/.github/workflows/e2e-test-with-domain.yaml
+++ b/.github/workflows/e2e-test-with-domain.yaml
@@ -32,6 +32,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v2
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
         
       - name: Pin Kubectl version
         uses: azure/setup-kubectl@v2.0


### PR DESCRIPTION
Currently, when e2e label is added to a PR, e2e tests are run against main branch which defeats the purpose of having such a label. This small change to workflows fixes it.
