### PR TITLE
Do not exit log collection script in case of errors

### DIFF
--- a/scripts/collect_k8s_logs.sh
+++ b/scripts/collect_k8s_logs.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
-set -e
 
 CLUSTER_NAME=$1
 AWS_REGION=$2


### PR DESCRIPTION
Removing `set -e` as in some cases getting pod logs isn't possible since the pod is in initializing state.

## Checklist
- [ ] I have successful end to end tests run (with & without domain)
- [ ] I have added unit tests (if applicable)
- [ ] I have user documentation (if applicable)
