### PR TITLE
Pin Python version in setup python workflow step

### DIFF
--- a/.github/workflows/e2e-test-no-domain.yaml
+++ b/.github/workflows/e2e-test-no-domain.yaml
@@ -50,7 +50,7 @@ jobs:
       - name: Setup Python environment
         uses: actions/setup-python@v4
         with:
-          python-version: '3.9'
+          python-version: '3.9.15'
       - run: |
           python -m pip install --upgrade pip
           pip install boto3

--- a/.github/workflows/e2e-test-no-domain.yaml
+++ b/.github/workflows/e2e-test-no-domain.yaml
@@ -50,7 +50,7 @@ jobs:
       - name: Setup Python environment
         uses: actions/setup-python@v4
         with:
-          python-version: '3.9.15'
+          python-version: '3.9.14'
       - run: |
           python -m pip install --upgrade pip
           pip install boto3

--- a/.github/workflows/e2e-test-with-domain.yaml
+++ b/.github/workflows/e2e-test-with-domain.yaml
@@ -50,7 +50,7 @@ jobs:
       - name: Setup Python environment
         uses: actions/setup-python@v4
         with:
-          python-version: '3.9'
+          python-version: '3.9.15'
       - run: |
           python -m pip install --upgrade pip
           pip install boto3

--- a/.github/workflows/e2e-test-with-domain.yaml
+++ b/.github/workflows/e2e-test-with-domain.yaml
@@ -50,7 +50,7 @@ jobs:
       - name: Setup Python environment
         uses: actions/setup-python@v4
         with:
-          python-version: '3.9.15'
+          python-version: '3.9.14'
       - run: |
           python -m pip install --upgrade pip
           pip install boto3


### PR DESCRIPTION
Since we export [PYTHONPATH in cmd.exec](https://github.com/atlassian-labs/data-center-terraform/blob/main/test/e2etest/installer_test.go#L114), Python version should be the same to be able to run aws_clean.py that uses boto3 library.
