### PR TITLE
CLIP-1690: Use bi-directional pv binding

### DIFF
--- a/modules/AWS/nfs/main.tf
+++ b/modules/AWS/nfs/main.tf
@@ -25,6 +25,10 @@ resource "kubernetes_persistent_volume" "nfs_shared_home" {
         volume_id = aws_ebs_volume.shared_home.id
       }
     }
+    claim_ref {
+      name      = "${local.nfs_name}-pvc"
+      namespace = var.namespace
+    }
   }
 }
 


### PR DESCRIPTION
This PR makes nfs PV-PVC binding bi-directional by using `claimRef` in PV spec which makes it impossible to bind a PV to any PVC but the one that is references in `claimRef`.

This happened a couple of times already to [e2e tests](https://github.com/atlassian-labs/data-center-terraform/actions/runs/3294484301/jobs/5432048390#step:11:4745). Jira helm release is never deployed, and uninstall.sh fails to delete infra because it fails to [delete this PVC](https//github.com/atlassian-labs/data-center-terraform/actions/runs/3294484301/jobs/5432048390#step:11:9910)

After examining logs, it turns out that Jira NFS volume is attached to **elasticsearch** PVC:

```
25m         Normal    SuccessfulAttachVolume   pod/elasticsearch-master-1                                          AttachVolume.Attach succeeded for volume "jira-nfs-pv" 
```
While Jira NFS PVC cannot be bound since its PV is bound to elasticsearch claim:

```
20s         Warning   FailedBinding            persistentvolumeclaim/jira-nfs-pvc                                  volume "jira-nfs-pv" already bound to a different claim. 
```
As a result, there's no nfs server pod for Jira because jira-nfs-pvc is stuck in Pending:

```
Name:          jira-nfs-pvc
Namespace:     atlassian
StorageClass:  gp2
Status:        Pending
Volume:        jira-nfs-pv
Labels:        <none>
Annotations:   <none>
Finalizers:    [kubernetes.io/pvc-protection]
Capacity:      0
Access Modes:  
VolumeMode:    Filesystem
Used By:       <none>
Events:
  Type     Reason         Age                  From                         Message
  ----     ------         ----                 ----                         -------
  Warning  FailedBinding  63s (x102 over 26m)  persistentvolume-controller  volume "jira-nfs-pv" already bound to a different claim. 
```
  
Jira pod is stuck in pending because its shared home PV cannot connect to NFS server (which was never created).

Also, Terraform cannot correctly remove Jira nfs pvc since it's used by a Jira pod that is pending (and it's pending because it uses an unbound PVC).

The original error is a race condition. Since all helm charts are deployed simultaneously, elasticsearch PVC may get bound to any  available PV - and PVs are created by Terraform.

## Checklist
- [x] I have successful end to end tests run (with & without domain)
- [ ] I have added unit tests (if applicable)
- [ ] I have user documentation (if applicable)
