### PR TITLE
CLIP-1646: Update aws and rds providers

### DIFF
--- a/modules/AWS/asg_ec2_tagging
+++ b/modules/AWS/asg_ec2_tagging
@@ -1,0 +1,8 @@
+# This is a generated file **DO NOT MODIFY THE CONTENT**
+
+locals {
+    # Terraform state settings
+    dynamodb_name = "atlassian_data_center_us_east_1_887764444972_tf_lock"
+    bucket_name   = "atlassian-data-center-us-east-1-887764444972-tf-state"
+    bucket_key    = "eugenetest/terraform.tfstate"
+}

--- a/modules/AWS/asg_ec2_tagging
+++ b/modules/AWS/asg_ec2_tagging
@@ -1,8 +1,0 @@
-# This is a generated file **DO NOT MODIFY THE CONTENT**
-
-locals {
-    # Terraform state settings
-    dynamodb_name = "atlassian_data_center_us_east_1_887764444972_tf_lock"
-    bucket_name   = "atlassian-data-center-us-east-1-887764444972-tf-state"
-    bucket_key    = "eugenetest/terraform.tfstate"
-}

--- a/modules/AWS/dynamodb/provider_version.tf
+++ b/modules/AWS/dynamodb/provider_version.tf
@@ -1,7 +1,7 @@
 terraform {
   required_providers {
     aws = {
-      version = "~> 3.74"
+      version = "~> 4.36"
     }
     kubernetes = {
       version = "~> 2.7"

--- a/modules/AWS/eks/provider_version.tf
+++ b/modules/AWS/eks/provider_version.tf
@@ -1,7 +1,7 @@
 terraform {
   required_providers {
     aws = {
-      version = "~> 3.74"
+      version = "~> 4.36"
     }
     kubernetes = {
       version = "~> 2.7"

--- a/modules/AWS/ingress/provider_version.tf
+++ b/modules/AWS/ingress/provider_version.tf
@@ -1,7 +1,7 @@
 terraform {
   required_providers {
     aws = {
-      version = "~> 3.74"
+      version = "~> 4.36"
     }
     kubernetes = {
       version = "~> 2.7"

--- a/modules/AWS/nfs/provider_version.tf
+++ b/modules/AWS/nfs/provider_version.tf
@@ -1,7 +1,7 @@
 terraform {
   required_providers {
     aws = {
-      version = "~> 3.74"
+      version = "~> 4.36"
     }
     kubernetes = {
       version = "~> 2.7"

--- a/modules/AWS/rds/locals.tf
+++ b/modules/AWS/rds/locals.tf
@@ -1,6 +1,6 @@
 locals {
   db_master_username = var.db_master_username == null ? "postgres" : var.db_master_username
-  db_master_password = var.db_master_password == null ? random_password.password.result : var.db_master_password
+  create_random_password = var.db_master_password == null ? true : false
   db_jdbc_connection = "jdbc:postgresql://${module.db.db_instance_endpoint}/${var.product}"
 
   # RDS major version is mapped to the lastest minor version for more details.

--- a/modules/AWS/rds/main.tf
+++ b/modules/AWS/rds/main.tf
@@ -42,8 +42,8 @@ module "db" {
 
   db_name                     = var.db_name
   username                    = local.db_master_username
-  password                    = local.db_master_password
-  create_random_password      = false
+  password                    = var.db_master_password
+  create_random_password      = local.create_random_password
   port                        = 5432
 
   create_db_subnet_group      = true
@@ -53,6 +53,7 @@ module "db" {
   maintenance_window          = "Mon:00:00-Mon:03:00"
   backup_window               = "03:00-06:00"
   storage_encrypted           = false
+
   # Snapshot settings
   snapshot_identifier         = var.snapshot_identifier
   allow_major_version_upgrade = var.snapshot_identifier != null
@@ -61,10 +62,4 @@ module "db" {
 
   skip_final_snapshot         = true
   apply_immediately           = true
-}
-
-resource "random_password" "password" {
-  length           = 12
-  special          = true
-  override_special = "!#$%^*(){}?,."
 }

--- a/modules/AWS/rds/main.tf
+++ b/modules/AWS/rds/main.tf
@@ -22,43 +22,44 @@ module "security_group" {
 }
 
 module "db" {
-  source  = "terraform-aws-modules/rds/aws"
-  version = "~> 3.0"
+  source                      = "terraform-aws-modules/rds/aws"
+  version                     = "~> 5.1"
 
-  identifier = var.rds_instance_identifier
+  identifier                  = var.rds_instance_identifier
 
-  create_db_option_group    = false
-  create_db_parameter_group = false
+  create_db_option_group      = false
+  create_db_parameter_group   = false
 
   # All available versions: https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/CHAP_PostgreSQL.html#PostgreSQL.Concepts
-  engine               = "postgres"
-  engine_version       = local.engine_version
-  family               = local.family             # DB parameter group
-  major_engine_version = var.major_engine_version # DB option group
-  instance_class       = var.instance_class
+  engine                      = "postgres"
+  engine_version              = local.engine_version
+  family                      = local.family             # DB parameter group
+  major_engine_version        = var.major_engine_version # DB option group
+  instance_class              = var.instance_class
 
-  allocated_storage = var.allocated_storage
-  iops              = var.iops
+  allocated_storage           = var.allocated_storage
+  iops                        = var.iops
 
-  name     = var.db_name
-  username = local.db_master_username
-  password = local.db_master_password
-  port     = 5432
+  db_name                     = var.db_name
+  username                    = local.db_master_username
+  password                    = local.db_master_password
+  port                        = 5432
 
-  subnet_ids             = var.vpc.private_subnets
-  vpc_security_group_ids = [module.security_group.security_group_id]
+  create_db_subnet_group      = true
+  subnet_ids                  = var.vpc.private_subnets
+  vpc_security_group_ids      = [module.security_group.security_group_id]
 
-  maintenance_window = "Mon:00:00-Mon:03:00"
-  backup_window      = "03:00-06:00"
+  maintenance_window          = "Mon:00:00-Mon:03:00"
+  backup_window               = "03:00-06:00"
 
   # Snapshot settings
   snapshot_identifier         = var.snapshot_identifier
   allow_major_version_upgrade = var.snapshot_identifier != null
 
-  backup_retention_period = 0
+  backup_retention_period     = 0
 
-  skip_final_snapshot = true
-  apply_immediately   = true
+  skip_final_snapshot         = true
+  apply_immediately           = true
 }
 
 resource "random_password" "password" {

--- a/modules/AWS/rds/main.tf
+++ b/modules/AWS/rds/main.tf
@@ -43,6 +43,7 @@ module "db" {
   db_name                     = var.db_name
   username                    = local.db_master_username
   password                    = local.db_master_password
+  create_random_password      = false
   port                        = 5432
 
   create_db_subnet_group      = true
@@ -51,7 +52,7 @@ module "db" {
 
   maintenance_window          = "Mon:00:00-Mon:03:00"
   backup_window               = "03:00-06:00"
-
+  storage_encrypted           = false
   # Snapshot settings
   snapshot_identifier         = var.snapshot_identifier
   allow_major_version_upgrade = var.snapshot_identifier != null

--- a/modules/AWS/rds/outputs.tf
+++ b/modules/AWS/rds/outputs.tf
@@ -8,7 +8,7 @@ output "rds_master_username" {
 }
 
 output "rds_master_password" {
-  value     = module.db.db_master_password
+  value     = module.db.db_instance_password
   sensitive = true
 }
 

--- a/modules/AWS/rds/provider_version.tf
+++ b/modules/AWS/rds/provider_version.tf
@@ -1,7 +1,7 @@
 terraform {
   required_providers {
     aws = {
-      version = "~> 3.74"
+      version = "~> 4.36"
     }
     kubernetes = {
       version = "~> 2.7"

--- a/modules/AWS/s3/provider_version.tf
+++ b/modules/AWS/s3/provider_version.tf
@@ -1,7 +1,7 @@
 terraform {
   required_providers {
     aws = {
-      version = "~> 3.74"
+      version = "~> 4.36"
     }
     kubernetes = {
       version = "~> 2.7"

--- a/modules/AWS/vpc/provider_version.tf
+++ b/modules/AWS/vpc/provider_version.tf
@@ -1,7 +1,7 @@
 terraform {
   required_providers {
     aws = {
-      version = "~> 3.74"
+      version = "~> 4.36"
     }
     kubernetes = {
       version = "~> 2.7"

--- a/modules/common/provider_version.tf
+++ b/modules/common/provider_version.tf
@@ -1,7 +1,7 @@
 terraform {
   required_providers {
     aws = {
-      version = "~> 3.74"
+      version = "~> 4.36"
     }
     kubernetes = {
       version = "~> 2.7"

--- a/modules/products/bamboo/provider_version.tf
+++ b/modules/products/bamboo/provider_version.tf
@@ -1,7 +1,7 @@
 terraform {
   required_providers {
     aws = {
-      version = "~> 3.74"
+      version = "~> 4.36"
     }
     kubernetes = {
       version = "~> 2.7"

--- a/modules/products/bitbucket/provider_version.tf
+++ b/modules/products/bitbucket/provider_version.tf
@@ -1,7 +1,7 @@
 terraform {
   required_providers {
     aws = {
-      version = "~> 3.74"
+      version = "~> 4.36"
     }
     kubernetes = {
       version = "~> 2.7"

--- a/modules/products/confluence/provider_version.tf
+++ b/modules/products/confluence/provider_version.tf
@@ -1,7 +1,7 @@
 terraform {
   required_providers {
     aws = {
-      version = "~> 3.74"
+      version = "~> 4.36"
     }
     kubernetes = {
       version = "~> 2.7"

--- a/modules/products/jira/provider_version.tf
+++ b/modules/products/jira/provider_version.tf
@@ -1,7 +1,7 @@
 terraform {
   required_providers {
     aws = {
-      version = "~> 3.74"
+      version = "~> 4.36"
     }
     kubernetes = {
       version = "~> 2.7"

--- a/modules/tfstate/provider_version.tf
+++ b/modules/tfstate/provider_version.tf
@@ -1,7 +1,7 @@
 terraform {
   required_providers {
     aws = {
-      version = "~> 3.74"
+      version = "~> 4.36"
     }
     kubernetes = {
       version = "~> 2.7"

--- a/provider_version.tf
+++ b/provider_version.tf
@@ -1,7 +1,7 @@
 terraform {
   required_providers {
     aws = {
-      version = "~> 3.74"
+      version = "~> 4.36"
     }
     kubernetes = {
       version = "~> 2.7"

--- a/test/unittest/database_test.go
+++ b/test/unittest/database_test.go
@@ -66,12 +66,6 @@ func TestDbVariablesPopulatedWithValidValues(t *testing.T) {
 	assert.EqualValues(t, inputAllocatedStorage, planAllocatedStorage)
 	assert.EqualValues(t, inputIops, planIops)
 	assert.EqualValues(t, true, planApplyImmediately)
-
-	// when db_master_password is not set
-	randomPwdKey := "random_password.password"
-	terraform.RequirePlannedValuesMapKeyExists(t, plan, randomPwdKey)
-	keyLength := plan.ResourcePlannedValuesMap[randomPwdKey].AttributeValues["length"]
-	assert.Equal(t, float64(12), keyLength)
 }
 
 func TestDbPostgresVersionMap(t *testing.T) {

--- a/test/unittest/database_test.go
+++ b/test/unittest/database_test.go
@@ -52,7 +52,7 @@ func TestDbVariablesPopulatedWithValidValues(t *testing.T) {
 	planDbSnapshotIdentifier := plan.ResourcePlannedValuesMap["module.db.module.db_instance.aws_db_instance.this[0]"].AttributeValues["snapshot_identifier"]
 	planUserName := plan.ResourcePlannedValuesMap["module.db.module.db_instance.aws_db_instance.this[0]"].AttributeValues["username"]
 	planEngine := plan.ResourcePlannedValuesMap["module.db.module.db_instance.aws_db_instance.this[0]"].AttributeValues["engine"]
-	planDbName := plan.ResourcePlannedValuesMap["module.db.module.db_instance.aws_db_instance.this[0]"].AttributeValues["name"]
+	planDbName := plan.ResourcePlannedValuesMap["module.db.module.db_instance.aws_db_instance.this[0]"].AttributeValues["db_name"]
 	planInstanceClass := plan.ResourcePlannedValuesMap["module.db.module.db_instance.aws_db_instance.this[0]"].AttributeValues["instance_class"]
 	planAllocatedStorage := plan.ResourcePlannedValuesMap["module.db.module.db_instance.aws_db_instance.this[0]"].AttributeValues["allocated_storage"]
 	planIops := plan.ResourcePlannedValuesMap["module.db.module.db_instance.aws_db_instance.this[0]"].AttributeValues["iops"]


### PR DESCRIPTION
This PR updates aws provider version to 4.36 and rds provider version to 5.1. Both are the latest as of now.

The following attributes were added to rds module (because they are true by default):

```
storage_encrypted          = false
create_random_password     = false
create_db_subnet_group      = true
```

Also, the following was changed in outputs:

```
output "rds_master_password" {
  value     = module.db.db_instance_password
  sensitive = true
}
```

No changes to any other aws resources.

This fixes a warning on each and every tf apply and destroy

```
Warning: Redundant ignore_changes element  on .terraform/modules/bamboo.database.db/modules/db_instance/main.tf line 20, in resource "aws_db_instance" "this":
  20: resource "aws_db_instance" "this" {
```

Important! Run `terraform init --update` to fetch new provider versions. This change is backward compatible, i.e. can be applied to infra created before version update. This still has to be extensively tested, that's why it's safer to use it to create new environments only.

## Checklist
- [x] I have successful end to end tests run (with & without domain)
- [ ] I have added unit tests (if applicable)
- [ ] I have user documentation (if applicable)
