### PR TITLE
CLIP-1680: Update action versions

### DIFF
--- a/.github/workflows/documentation-build.yaml
+++ b/.github/workflows/documentation-build.yaml
@@ -7,8 +7,8 @@ jobs:
   deploy:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-python@v2
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
         with:
           python-version: 3.x
       - name: Install mkdocs requirements

--- a/.github/workflows/documentation-deploy.yaml
+++ b/.github/workflows/documentation-deploy.yaml
@@ -9,8 +9,8 @@ jobs:
   deploy:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-python@v2
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
         with:
           python-version: 3.x
       - name: Install mkdocs requirements

--- a/.github/workflows/e2e-test-no-domain.yaml
+++ b/.github/workflows/e2e-test-no-domain.yaml
@@ -33,12 +33,12 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3.1.0
         with:
           ref: ${{ github.event.pull_request.head.sha }}
 
       - name: Pin Kubectl version
-        uses: azure/setup-kubectl@v2.0
+        uses: azure/setup-kubectl@v3.0
         with:
           version: 'v1.24.0'
 
@@ -61,13 +61,13 @@ jobs:
         run: |
           go version
           go get -v -t -d ./... && go mod tidy
-          echo ::set-output name=exit_code::$?
+          echo "exit_code=$?" >> $GITHUB_OUTPUT
 
       - name: Create test output directory
         run: mkdir test/e2etest/artifacts
 
       - name: Add private SSH key for Bitbucket tests
-        uses: shimataro/ssh-key-action@v2
+        uses: shimataro/ssh-key-action@v2.3.1
         with:
           key: ${{ secrets.BITBUCKET_E2E_TEST_PRIV_SSH_KEY }}
           name: bitbucket-e2e # optional
@@ -88,7 +88,7 @@ jobs:
 
       - name: Upload test log files
         if: always()
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3.1.1
         with:
           name: e2e-test-artifacts
           path: test/e2etest/artifacts/

--- a/.github/workflows/e2e-test-with-domain.yaml
+++ b/.github/workflows/e2e-test-with-domain.yaml
@@ -33,7 +33,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           ref: ${{ github.event.pull_request.head.sha }}
 
@@ -61,13 +61,13 @@ jobs:
         run: |
           go version
           go get -v -t -d ./... && go mod tidy
-          echo ::set-output name=exit_code::$?
+          echo "exit_code=$?" >> $GITHUB_OUTPUT
 
       - name: Create test output directory
         run: mkdir test/e2etest/artifacts
 
       - name: Add private SSH key for Bitbucket tests
-        uses: shimataro/ssh-key-action@v2
+        uses: shimataro/ssh-key-action@v2.3.1
         with:
           key: ${{ secrets.BITBUCKET_E2E_TEST_PRIV_SSH_KEY }}
           name: bitbucket-e2e # optional
@@ -89,7 +89,7 @@ jobs:
 
       - name: Upload test log files
         if: always()
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3.1.1
         with:
           name: e2e-test-artifacts
           path: test/e2etest/artifacts/

--- a/.github/workflows/unit-test.yaml
+++ b/.github/workflows/unit-test.yaml
@@ -20,7 +20,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         
       - name: Setup Go environment
         uses: actions/setup-go@v3


### PR DESCRIPTION
This PR bumps versions of used GitHub actions

🟢 https://github.com/atlassian-labs/data-center-terraform/actions/runs/3333209508

There are still a couple of warnings:
* ssh key action - https://github.com/shimataro/ssh-key-action/issues/207
* set-output command deprecation - still pops up even though it's not used in our actions, perhaps it's in one of the used actions themselves

## Checklist
- [x] I have successful end to end tests run (with & without domain)
- [ ] I have added unit tests (if applicable)
- [ ] I have user documentation (if applicable)
