### PR TITLE
CLIP-1700: Disable db auto updates

### DIFF
--- a/modules/AWS/rds/main.tf
+++ b/modules/AWS/rds/main.tf
@@ -52,6 +52,7 @@ module "db" {
 
   maintenance_window          = "Mon:00:00-Mon:03:00"
   backup_window               = "03:00-06:00"
+  auto_minor_version_upgrade  = false
   storage_encrypted           = false
 
   # Snapshot settings


### PR DESCRIPTION
> auto_minor_version_upgrade bool
Description: Indicates that minor engine upgrades will be applied automatically to the DB instance during the maintenance window. Default: true

This PR sets auto upgrade to minor versions during the upgrade. With `auto_minor_version_upgrade` set to true (which is by default), db is updated and the 2nd terraform apply fails since it tries to downgrade the version.

```
Error: updating RDS DB Instance (atlas-e2etest-ga28xb-confluence-db): InvalidParameterCombination: Cannot upgrade postgres from 11.16 to 11.14
5922	status code: 400, request id: 2679cceb-9c0e-4e1f-845c-18bcf53c9222
5923
5924  with module.confluence[0].module.database.module.db.module.db_instance.aws_db_instance.this[0],
5925  on .terraform/modules/confluence.database.db/modules/db_instance/main.tf line 32, in resource "aws_db_instance" "this":
5926  32: resource "aws_db_instance" "this" {
5929 Error: updating RDS DB Instance (atlas-e2etest-ga28xb-jira-db): InvalidParameterCombination: Cannot upgrade postgres from 12.11 to 12.9
5930	status code: 400, request id: 8f5d9701-1d03-4e55-b241-0166a91b7894
5931
5932  with module.jira[0].module.database.module.db.module.db_instance.aws_db_instance.this[0],
5933  on .terraform/modules/jira.database.db/modules/db_instance/main.tf line 32, in resource "aws_db_instance" "this":
5934  32: resource "aws_db_instance" "this" {
5935 
```

## Checklist
- [x] I have successful end to end tests run (with & without domain)
- [ ] I have added unit tests (if applicable)
- [ ] I have user documentation (if applicable)
