### PR TITLE
CLIP-1707: Set termination grace period to 0 by default

### DIFF
--- a/config.tfvars
+++ b/config.tfvars
@@ -110,7 +110,7 @@ jira_replica_count = 1
 # Termination grace period
 # Under certain conditions, pods may be stuck in a Terminating state which forces shared-home pvc to be stuck
 # in Terminating too causing Terraform destroy error (timing out waiting for a deleted PVC).
-# Termination grace period is 0 by default. You can override it if for some reason you need a different value
+# Termination grace period is 0 by default which instructs kubelet to forcefully terminate the pod. You can override it if for some reason you need a different value
 #jira_termination_grace_period = 0
 
 # By default, Jira Software will use the version defined in the Helm chart. If you wish to override the version, uncomment
@@ -195,7 +195,7 @@ confluence_replica_count = 1
 # Termination grace period
 # Under certain conditions, pods may be stuck in a Terminating state which forces shared-home pvc to be stuck
 # in Terminating too causing Terraform destroy error (timing out waiting for a deleted PVC).
-# Termination grace period is 0 by default. You can override it if for some reason you need a different value
+# Termination grace period is 0 by default which instructs kubelet to forcefully terminate the pod. You can override it if for some reason you need a different value
 # confluence_termination_grace_period = 0
 
 # By default, Confluence will use the version defined in the Helm chart. If you wish to override the version, uncomment
@@ -287,7 +287,7 @@ bitbucket_replica_count = 1
 # Termination grace period
 # Under certain conditions, pods may be stuck in a Terminating state which forces shared-home pvc to be stuck
 # in Terminating too causing Terraform destroy error (timing out waiting for a deleted PVC).
-# Termination grace period is 0 by default. You can override it if for some reason you need a different value
+# Termination grace period is 0 by default which instructs kubelet to forcefully terminate the pod. You can override it if for some reason you need a different value
 #bitbucket_termination_grace_period = 0
 
 # By default, Bitbucket will use the version defined in the Bitbucket Helm chart:
@@ -461,6 +461,6 @@ bamboo_db_name                 = "bamboo"
 # Termination grace period
 # Under certain conditions, pods may be stuck in a Terminating state which forces shared-home pvc to be stuck
 # in Terminating too causing Terraform destroy error (timing out waiting for a deleted PVC).
-# Termination grace period is 0 by default. You can override it if for some reason you need a different value.
+# Termination grace period is 0 by default which instructs kubelet to forcefully terminate the pod. You can override it if for some reason you need a different value.
 # This will apply to both Bamboo server and agent pods.
 #bamboo_termination_grace_period = 0

--- a/config.tfvars
+++ b/config.tfvars
@@ -109,8 +109,8 @@ jira_replica_count = 1
 
 # Termination grace period
 # Under certain conditions, pods may be stuck in a Terminating state which forces shared-home pvc to be stuck
-# in Terminating too causing Terraform destroy error (timing out waiting for a deleted PVC). Set termination graceful period to 0
-# if you encounter such an issue
+# in Terminating too causing Terraform destroy error (timing out waiting for a deleted PVC).
+# Termination grace period is 0 by default. You can override it if for some reason you need a different value
 #jira_termination_grace_period = 0
 
 # By default, Jira Software will use the version defined in the Helm chart. If you wish to override the version, uncomment
@@ -194,8 +194,8 @@ confluence_replica_count = 1
 
 # Termination grace period
 # Under certain conditions, pods may be stuck in a Terminating state which forces shared-home pvc to be stuck
-# in Terminating too causing Terraform destroy error (timing out waiting for a deleted PVC). Set termination graceful period to 0
-# if you encounter such an issue.
+# in Terminating too causing Terraform destroy error (timing out waiting for a deleted PVC).
+# Termination grace period is 0 by default. You can override it if for some reason you need a different value
 # confluence_termination_grace_period = 0
 
 # By default, Confluence will use the version defined in the Helm chart. If you wish to override the version, uncomment
@@ -286,8 +286,8 @@ bitbucket_replica_count = 1
 
 # Termination grace period
 # Under certain conditions, pods may be stuck in a Terminating state which forces shared-home pvc to be stuck
-# in Terminating too causing Terraform destroy error (timing out waiting for a deleted PVC). Set termination graceful period to 0
-# if you encounter such an issue
+# in Terminating too causing Terraform destroy error (timing out waiting for a deleted PVC).
+# Termination grace period is 0 by default. You can override it if for some reason you need a different value
 #bitbucket_termination_grace_period = 0
 
 # By default, Bitbucket will use the version defined in the Bitbucket Helm chart:
@@ -460,6 +460,7 @@ bamboo_db_name                 = "bamboo"
 
 # Termination grace period
 # Under certain conditions, pods may be stuck in a Terminating state which forces shared-home pvc to be stuck
-# in Terminating too causing Terraform destroy error (timing out waiting for a deleted PVC). Set termination graceful period to 0
-# if you encounter such an issue. This will apply to both Bamboo server and agent pods.
+# in Terminating too causing Terraform destroy error (timing out waiting for a deleted PVC).
+# Termination grace period is 0 by default. You can override it if for some reason you need a different value.
+# This will apply to both Bamboo server and agent pods.
 #bamboo_termination_grace_period = 0

--- a/test/e2etest/test-config.tfvars.tmpl
+++ b/test/e2etest/test-config.tfvars.tmpl
@@ -64,9 +64,6 @@ number_of_bamboo_agents = 3
 # for details
 bamboo_dataset_url = "https://bamboo-test-datasets.s3.amazonaws.com/testing_dataset_minimal.zip"
 
-# To fix "pvc still exists with finalizers" error while uninstalling
-bamboo_termination_grace_period = 0
-
 ################################################################################
 # Jira Settings
 ################################################################################
@@ -95,8 +92,6 @@ jira_db_allocated_storage    = 100
 jira_db_iops                 = 1000
 jira_db_name                 = "jira"
 
-jira_termination_grace_period = 0
-
 ################################################################################
 # Confluence Settings
 ################################################################################
@@ -108,8 +103,6 @@ confluence_nfs_requests_cpu    = "0.25"
 confluence_nfs_requests_memory = "256Mi"
 confluence_nfs_limits_cpu      = "0.25"
 confluence_nfs_limits_memory   = "256Mi"
-
-confluence_termination_grace_period = 0
 
 ################################################################################
 # Bitbucket Settings
@@ -128,5 +121,3 @@ bitbucket_nfs_requests_cpu    = "0.25"
 bitbucket_nfs_requests_memory = "256Mi"
 bitbucket_nfs_limits_cpu      = "0.25"
 bitbucket_nfs_limits_memory   = "256Mi"
-
-bitbucket_termination_grace_period = 0

--- a/variables.tf
+++ b/variables.tf
@@ -159,7 +159,7 @@ variable "jira_replica_count" {
 variable "jira_termination_grace_period" {
   description = "Termination grace period in seconds"
   type        = number
-  default     = 30
+  default     = 0
 }
 
 variable "jira_installation_timeout" {
@@ -344,7 +344,7 @@ variable "confluence_replica_count" {
 variable "confluence_termination_grace_period" {
   description = "Termination grace period in seconds"
   type        = number
-  default     = 30
+  default     = 0
 }
 
 variable "confluence_installation_timeout" {
@@ -564,7 +564,7 @@ variable "bitbucket_replica_count" {
 variable "bitbucket_termination_grace_period" {
   description = "Termination grace period in seconds"
   type        = number
-  default     = 30
+  default     = 0
 }
 
 variable "bitbucket_installation_timeout" {
@@ -842,7 +842,7 @@ variable "bamboo_installation_timeout" {
 variable "bamboo_termination_grace_period" {
   description = "Termination grace period in seconds"
   type        = number
-  default     = 30
+  default     = 0
 }
 
 variable "bamboo_agent_version_tag" {


### PR DESCRIPTION
This PR sets `termination_grace_period` to 0 by default to avoid having pods stuck in Pending and holding deletion of PVC.

Also, removing overrides from test tfvars, and tweaking variable descrition

## Checklist
- [x] I have successful end to end tests run (with & without domain)
- [ ] I have added unit tests (if applicable)
- [ ] I have user documentation (if applicable)
