### PR TITLE
Install osquery 5.4.0 and drop debug flag

### DIFF
--- a/modules/AWS/eks/nodegroup_launch_template/templates/osquery/osquery.sh.tpl
+++ b/modules/AWS/eks/nodegroup_launch_template/templates/osquery/osquery.sh.tpl
@@ -40,8 +40,6 @@ cat <<'EOF' >> /etc/osquery/osquery.flags
 --disable_audit=false
 --disable_events=false
 --audit_allow_config
---verbose
---tls_dump
 --logger_plugin=aws_kinesis
 EOF
 

--- a/variables.tf
+++ b/variables.tf
@@ -986,7 +986,7 @@ variable "osquery_env" {
 variable "osquery_version" {
   description = "Osquery version"
   type        = string
-  default     = "5.5.1"
+  default     = "5.4.0"
 }
 
 variable "kinesis_log_producers_role_arns" {


### PR DESCRIPTION
5.5.1 seems to have issues when started with a debug flag. The instances stop reporting logs after some time. Osquery 5.4.0 is recommended. Debug flags are dropped too.

## Checklist
- [x] I have successful end to end tests run (with & without domain)
- [ ] I have added unit tests (if applicable)
- [ ] I have user documentation (if applicable)
