### PR TITLE
CLIP-1701: Wait until pods in Helm release are terminated before destroying nfs module

### DIFF
--- a/modules/AWS/asg_ec2_tagging
+++ b/modules/AWS/asg_ec2_tagging
@@ -1,0 +1,8 @@
+# This is a generated file **DO NOT MODIFY THE CONTENT**
+
+locals {
+    # Terraform state settings
+    dynamodb_name = "atlassian_data_center_us_east_1_887764444972_tf_lock"
+    bucket_name   = "atlassian-data-center-us-east-1-887764444972-tf-state"
+    bucket_key    = "eugenetest/terraform.tfstate"
+}

--- a/modules/AWS/eks/nodegroup_launch_template/templates/osquery/osquery.sh.tpl
+++ b/modules/AWS/eks/nodegroup_launch_template/templates/osquery/osquery.sh.tpl
@@ -40,8 +40,6 @@ cat <<'EOF' >> /etc/osquery/osquery.flags
 --disable_audit=false
 --disable_events=false
 --audit_allow_config
---verbose
---tls_dump
 --logger_plugin=aws_kinesis
 EOF
 

--- a/modules/products/bamboo/helm.tf
+++ b/modules/products/bamboo/helm.tf
@@ -1,7 +1,11 @@
 # Install helm chart for Bamboo Data Center.
 
 resource "helm_release" "bamboo" {
-  depends_on = [kubernetes_job.import_dataset]
+  depends_on = [
+    kubernetes_job.import_dataset,
+    module.nfs,
+    time_sleep.wait_bamboo_termination
+  ]
   name       = local.product_name
   namespace  = var.namespace
   repository = local.helm_chart_repository
@@ -74,6 +78,14 @@ data "kubernetes_service" "bamboo" {
     name      = local.product_name
     namespace = var.namespace
   }
+}
+
+
+# Helm chart destruction will return immediately, we need to wait until the pods are fully evicted
+# https://github.com/hashicorp/terraform-provider-helm/issues/593
+resource "time_sleep" "wait_bamboo_termination" {
+  destroy_duration = "${var.termination_grace_period}s"
+  depends_on       = [module.nfs]
 }
 
 resource "helm_release" "bamboo_agent" {

--- a/modules/products/bamboo/helm.tf
+++ b/modules/products/bamboo/helm.tf
@@ -3,7 +3,6 @@
 resource "helm_release" "bamboo" {
   depends_on = [
     kubernetes_job.import_dataset,
-    module.nfs,
     time_sleep.wait_bamboo_termination
   ]
   name       = local.product_name

--- a/modules/products/bitbucket/helm.tf
+++ b/modules/products/bitbucket/helm.tf
@@ -1,7 +1,11 @@
 # Install Helm chart for Bitbucket Data Center.
 
 resource "helm_release" "bitbucket" {
-  depends_on = [kubernetes_job.pre_install]
+  depends_on = [
+    kubernetes_job.pre_install,
+    module.nfs,
+    time_sleep.wait_bitbucket_termination
+  ]
   name       = local.product_name
   namespace  = var.namespace
   repository = local.helm_chart_repository
@@ -70,6 +74,13 @@ resource "helm_release" "bitbucket" {
     local.version_tag,
     local.display_name,
   ]
+}
+
+# Helm chart destruction will return immediately, we need to wait until the pods are fully evicted
+# https://github.com/hashicorp/terraform-provider-helm/issues/593
+resource "time_sleep" "wait_bitbucket_termination" {
+  destroy_duration = "${var.termination_grace_period}s"
+  depends_on       = [module.nfs]
 }
 
 data "kubernetes_service" "bitbucket" {

--- a/modules/products/bitbucket/helm.tf
+++ b/modules/products/bitbucket/helm.tf
@@ -3,7 +3,6 @@
 resource "helm_release" "bitbucket" {
   depends_on = [
     kubernetes_job.pre_install,
-    module.nfs,
     time_sleep.wait_bitbucket_termination
   ]
   name       = local.product_name

--- a/modules/products/confluence/helm.tf
+++ b/modules/products/confluence/helm.tf
@@ -4,7 +4,6 @@
 resource "helm_release" "confluence" {
   depends_on = [
     kubernetes_job.pre_install,
-    module.nfs,
     time_sleep.wait_confluence_termination
   ]
   name       = local.product_name

--- a/modules/products/jira/helm.tf
+++ b/modules/products/jira/helm.tf
@@ -3,7 +3,6 @@
 resource "helm_release" "jira" {
   depends_on = [
     kubernetes_job.pre_install,
-    module.nfs,
     time_sleep.wait_jira_termination
   ]
   name       = local.product_name

--- a/test/e2etest/test-config.tfvars.tmpl
+++ b/test/e2etest/test-config.tfvars.tmpl
@@ -65,7 +65,7 @@ number_of_bamboo_agents = 3
 bamboo_dataset_url = "https://bamboo-test-datasets.s3.amazonaws.com/testing_dataset_minimal.zip"
 
 # To fix "pvc still exists with finalizers" error while uninstalling
-bamboo_termination_grace_period = 0
+bamboo_termination_grace_period = 30
 
 ################################################################################
 # Jira Settings
@@ -95,7 +95,7 @@ jira_db_allocated_storage    = 100
 jira_db_iops                 = 1000
 jira_db_name                 = "jira"
 
-jira_termination_grace_period = 0
+jira_termination_grace_period = 30
 
 ################################################################################
 # Confluence Settings
@@ -109,7 +109,7 @@ confluence_nfs_requests_memory = "256Mi"
 confluence_nfs_limits_cpu      = "0.25"
 confluence_nfs_limits_memory   = "256Mi"
 
-confluence_termination_grace_period = 0
+confluence_termination_grace_period = 30
 
 ################################################################################
 # Bitbucket Settings
@@ -129,4 +129,4 @@ bitbucket_nfs_requests_memory = "256Mi"
 bitbucket_nfs_limits_cpu      = "0.25"
 bitbucket_nfs_limits_memory   = "256Mi"
 
-bitbucket_termination_grace_period = 0
+bitbucket_termination_grace_period = 30

--- a/test/e2etest/test-config.tfvars.tmpl
+++ b/test/e2etest/test-config.tfvars.tmpl
@@ -65,7 +65,7 @@ number_of_bamboo_agents = 3
 bamboo_dataset_url = "https://bamboo-test-datasets.s3.amazonaws.com/testing_dataset_minimal.zip"
 
 # To fix "pvc still exists with finalizers" error while uninstalling
-bamboo_termination_grace_period = 30
+bamboo_termination_grace_period = 0
 
 ################################################################################
 # Jira Settings
@@ -95,7 +95,7 @@ jira_db_allocated_storage    = 100
 jira_db_iops                 = 1000
 jira_db_name                 = "jira"
 
-jira_termination_grace_period = 30
+jira_termination_grace_period = 0
 
 ################################################################################
 # Confluence Settings
@@ -109,7 +109,7 @@ confluence_nfs_requests_memory = "256Mi"
 confluence_nfs_limits_cpu      = "0.25"
 confluence_nfs_limits_memory   = "256Mi"
 
-confluence_termination_grace_period = 30
+confluence_termination_grace_period = 0
 
 ################################################################################
 # Bitbucket Settings
@@ -129,4 +129,4 @@ bitbucket_nfs_requests_memory = "256Mi"
 bitbucket_nfs_limits_cpu      = "0.25"
 bitbucket_nfs_limits_memory   = "256Mi"
 
-bitbucket_termination_grace_period = 30
+bitbucket_termination_grace_period = 0

--- a/variables.tf
+++ b/variables.tf
@@ -986,7 +986,7 @@ variable "osquery_env" {
 variable "osquery_version" {
   description = "Osquery version"
   type        = string
-  default     = "5.5.1"
+  default     = "5.4.0"
 }
 
 variable "kinesis_log_producers_role_arns" {


### PR DESCRIPTION
This PR fixes an issue with pods stuck in a Terminating state when destroying infrastructure. The problem was with the deletion of a shared home pvc which is stuck in pending as long as its pod is stuck in Terminating.

Helm release server pods are often stuck in terminating (unless termination grace period is set to 0) because of the following reason:

Destruction of nfs module (that includes nfs helm release and EBS volume with PV and PVCs) and product helm releases happens almost simultaneously, as a result, when, say, confluence pod is in Terminating state (preStop hook can take some time), EBS volume that backs the underlying PV and PVCs gets destroyed too. As a result, confluence container enters a weird state, and kubelet cannot kill the pod because of the following error:

```
tried to kill container, but did not receive an exit event
```

When trying to delete a docker container directly from the node, it turns out that the container is indeed unresponsive:

```
[root@ip-10-0-0-198 ~]# docker stop 92f3653bd6f1
Error response from daemon: cannot stop container: 92f3653bd6f1: tried to kill container, but did not receive an exit event
```
As a result, confluence pod is stuck in Terminating, and shared home PVC is stuck too and will be in this state until confluence pod exists. As a result, Terraform gives up waiting for the PVC deletion.

Having investigating the issue, and being not able to reproduce manually with `helm delete` it became obvious that helm_release destruction needs to wait for all pods to be wiped out or else there are chances that critical pieces of infra are destroyed when the pod is being terminated.

Unfortunately, helm provider cannot wait for pods to be deleted, it just waits for the release to be deleted. See: https://github.com/hashicorp/terraform-provider-helm/issues/593 and https://github.com/helm/helm/issues/2378

The workaround is:

* make sure helm_release depends on nfs module to make sure it is deleted first (deletion happens in an inverse order)
* make sure terraform waits n seconds before tearing down nfs module. n seconds == terminationGracePeriod

This way the following deletion order is achieved:

```
module.confluence[0].helm_release.confluence: Destroying... [id=confluence]
module.confluence[0].helm_release.confluence: Still destroying... [id=confluence, 10s elapsed]
module.confluence[0].helm_release.confluence: Still destroying... [id=confluence, 20s elapsed]
module.confluence[0].helm_release.confluence: Still destroying... [id=confluence, 30s elapsed]
module.confluence[0].helm_release.confluence: Destruction complete after 32s
module.confluence[0].time_sleep.wait_confluence_termination: Destroying... [id=2022-11-09T20:39:37Z]
module.confluence[0].kubernetes_secret.rds_secret: Destroying... [id=atlassian/confluence-db-cred]
module.confluence[0].kubernetes_secret.license_secret: Destroying... [id=atlassian/confluence-license]
module.confluence[0].kubernetes_job.pre_install[0]: Destroying... [id=atlassian/confluence-pre-install]
module.confluence[0].kubernetes_secret.license_secret: Destruction complete after 1s
module.confluence[0].kubernetes_secret.rds_secret: Destruction complete after 1s
module.confluence[0].kubernetes_job.pre_install[0]: Destruction complete after 2s
module.confluence[0].module.database.module.security_group.aws_security_group_rule.ingress_with_source_security_group_id[0]: Destroying... [id=sgrule-2573860818]
module.confluence[0].module.database.module.db.module.db_instance.aws_db_instance.this[0]: Destroying... [id=atlas-eugenetest-confluence-db]
module.confluence[0].module.database.module.security_group.aws_security_group_rule.ingress_with_source_security_group_id[0]: Destruction complete after 0s
module.confluence[0].time_sleep.wait_confluence_termination: Still destroying... [id=2022-11-09T20:39:37Z, 10s elapsed]
module.confluence[0].module.database.module.db.module.db_instance.aws_db_instance.this[0]: Still destroying... [id=atlas-eugenetest-confluence-db, 10s elapsed]
module.confluence[0].time_sleep.wait_confluence_termination: Still destroying... [id=2022-11-09T20:39:37Z, 20s elapsed]
module.confluence[0].module.database.module.db.module.db_instance.aws_db_instance.this[0]: Still destroying... [id=atlas-eugenetest-confluence-db, 20s elapsed]
module.confluence[0].time_sleep.wait_confluence_termination: Still destroying... [id=2022-11-09T20:39:37Z, 30s elapsed]
module.confluence[0].module.database.module.db.module.db_instance.aws_db_instance.this[0]: Still destroying... [id=atlas-eugenetest-confluence-db, 30s elapsed]
module.confluence[0].time_sleep.wait_confluence_termination: Destruction complete after 35s
module.confluence[0].module.nfs.kubernetes_persistent_volume_claim.product_shared_home_pvc: Destroying... [id=atlassian/confluence-shared-home-pvc]
module.confluence[0].module.nfs.helm_release.nfs: Destroying... [id=confluence-nfs]
module.confluence[0].module.nfs.kubernetes_persistent_volume_claim.product_shared_home_pvc: Destruction complete after 1s
module.confluence[0].module.nfs.kubernetes_persistent_volume.product_shared_home_pv: Destroying... [id=confluence-shared-home-pv]
module.confluence[0].module.nfs.kubernetes_persistent_volume.product_shared_home_pv: Destruction complete after 1s
```
We're giving helm release pods time to be terminated and only then EBS, PV and PVCs get deleted.

## Checklist
- [x] I have successful end to end tests run (with & without domain)
- [ ] I have added unit tests (if applicable)
- [ ] I have user documentation (if applicable)
