### PR TITLE
CLIP-1673: Test with domain install 2 times in a row

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -66,3 +66,6 @@ outputs.json
 
 # go packages
 test/pkg
+
+# File created by tagging resource
+modules/AWS/asg_ec2_tagging

--- a/test/e2etest/installer_test.go
+++ b/test/e2etest/installer_test.go
@@ -25,9 +25,7 @@ func TestInstaller(t *testing.T) {
 	runInstallScript(testConfig.ConfigPath)
 
 	// run again with same config. This is to assure that the `re-apply` action finishes without any issue.
-	if !useDomain {
-		runInstallScript(testConfig.ConfigPath)
-	}
+	runInstallScript(testConfig.ConfigPath)
 
 	clusterHealthTests(t, testConfig)
 	checkAGSAndEC2Tags(t, testConfig)


### PR DESCRIPTION
The issue with terraform apply 2 times in a row cannot be reproduced anymore. See:

* https://github.com/atlassian-labs/data-center-terraform/actions/runs/3457214411/jobs/5770494962#step:11:5251
* https://github.com/atlassian-labs/data-center-terraform/actions/runs/3457914723/jobs/5771815875#step:11:5261

Perhaps, updating AWS provider version has fixed it. 

## Checklist
- [x] I have successful end to end tests run (with & without domain)
- [ ] I have added unit tests (if applicable)
- [ ] I have user documentation (if applicable)
