### PR TITLE
CLIP-1708: Fix use of local helm charts

### DIFF
--- a/config.tfvars
+++ b/config.tfvars
@@ -94,8 +94,8 @@ max_cluster_capacity = 5
 # Jira Settings
 ################################################################################
 
-# Helm chart version of Jira
-jira_helm_chart_version = "1.5.0"
+# Helm chart version of Jira. By default the latest version is installed.
+# jira_helm_chart_version = "<helm_chart_version>"
 
 # Number of Jira application nodes
 # Note: For initial installation this value needs to be set to 1 and it can be changed only after Jira is fully
@@ -179,8 +179,8 @@ jira_db_name = "jira"
 # Confluence Settings
 ################################################################################
 
-# Helm chart version of Confluence
-confluence_helm_chart_version = "1.5.1"
+# Helm chart version of Confluence. By default the latest version is installed.
+# confluence_helm_chart_version = "<helm_chart_version>"
 
 # Number of Confluence application nodes
 # Note: For initial installation this value needs to be set to 1 and it can be changed only after Confluence is fully
@@ -273,8 +273,8 @@ confluence_collaborative_editing_enabled = true
 # Bitbucket Settings
 ################################################################################
 
-# Helm chart version of Bitbucket
-bitbucket_helm_chart_version = "1.5.0"
+# Helm chart version of Bitbucket. By default the latest version is installed.
+# bitbucket_helm_chart_version = "<helm_chart_version>"
 
 # Number of Bitbucket application nodes
 bitbucket_replica_count = 1
@@ -378,9 +378,9 @@ bitbucket_db_name = "bitbucket"
 # Bamboo Settings
 ################################################################################
 
-# Helm chart version of Bamboo and Bamboo agent instances
-bamboo_helm_chart_version       = "1.5.0"
-bamboo_agent_helm_chart_version = "1.5.0"
+# Helm chart version of Bamboo and Bamboo agent instances. By default the latest version is installed.
+# bamboo_helm_chart_version       = "<helm_chart_version>"
+# bamboo_agent_helm_chart_version = "<helm_chart_version>"
 
 # By default, Bamboo and the Bamboo Agent will use the versions defined in their respective Helm charts:
 # https://github.com/atlassian/data-center-helm-charts/blob/main/src/main/charts/bamboo/Chart.yaml

--- a/dc-infrastructure.tf
+++ b/dc-infrastructure.tf
@@ -128,6 +128,9 @@ module "jira" {
   nfs_limits_memory   = var.jira_nfs_limits_memory
 
   shared_home_snapshot_id = var.jira_shared_home_snapshot_id
+
+  # If local Helm charts path is provided, Terraform will then install using local charts and ignores remote registry
+  local_jira_chart_path   = local.local_jira_chart_path
 }
 
 module "confluence" {
@@ -249,4 +252,7 @@ module "bitbucket" {
   elasticsearch_replicas        = var.bitbucket_elasticsearch_replicas
 
   shared_home_snapshot_id = var.bitbucket_shared_home_snapshot_id
+
+  # If local Helm charts path is provided, Terraform will then install using local charts and ignores remote registry
+  local_bitbucket_chart_path = local.local_bitbucket_chart_path
 }

--- a/locals.tf
+++ b/locals.tf
@@ -11,6 +11,8 @@ locals {
   shared_home_size = length(var.products) == 0 || (local.install_bitbucket && length(var.products) == 1) ? null : "5Gi"
 
   local_confluence_chart_path = var.local_helm_charts_path != "" && var.confluence_install_local_chart ? "${var.local_helm_charts_path}/confluence" : ""
+  local_bitbucket_chart_path  = var.local_helm_charts_path != "" && var.bitbucket_install_local_chart ? "${var.local_helm_charts_path}/bitbucket" : ""
+  local_jira_chart_path       = var.local_helm_charts_path != "" && var.jira_install_local_chart ? "${var.local_helm_charts_path}/jira" : ""
   local_bamboo_chart_path     = var.local_helm_charts_path != "" && var.bamboo_install_local_chart ? "${var.local_helm_charts_path}/bamboo" : ""
   local_agent_chart_path      = var.local_helm_charts_path != "" && var.bamboo_install_local_chart ? "${var.local_helm_charts_path}/bamboo-agent" : ""
 }

--- a/modules/products/bitbucket/helm.tf
+++ b/modules/products/bitbucket/helm.tf
@@ -5,7 +5,7 @@ resource "helm_release" "bitbucket" {
   name       = local.product_name
   namespace  = var.namespace
   repository = local.helm_chart_repository
-  chart      = local.product_name
+  chart      = local.bitbucket_helm_chart_name
   version    = local.bitbucket_helm_chart_version
   timeout    = var.installation_timeout * 60
 

--- a/modules/products/bitbucket/locals.tf
+++ b/modules/products/bitbucket/locals.tf
@@ -1,8 +1,12 @@
 locals {
   product_name = "bitbucket"
 
-  helm_chart_repository        = "https://atlassian.github.io/data-center-helm-charts"
-  bitbucket_helm_chart_version = var.bitbucket_configuration["helm_version"]
+  # Install local bitbucket helm charts if local path is provided
+  use_local_chart              = fileexists("${var.local_bitbucket_chart_path}/Chart.yaml")
+  helm_chart_repository        = local.use_local_chart ? null : "https://atlassian.github.io/data-center-helm-charts"
+  bitbucket_helm_chart_name    = local.use_local_chart ? var.local_bitbucket_chart_path : local.product_name
+  bitbucket_helm_chart_version = local.use_local_chart ? null : var.bitbucket_configuration["helm_version"]
+
 
   bitbucket_software_resources = {
     "minHeap" : var.bitbucket_configuration["min_heap"]

--- a/modules/products/bitbucket/variables.tf
+++ b/modules/products/bitbucket/variables.tf
@@ -75,6 +75,16 @@ variable "installation_timeout" {
   }
 }
 
+variable "local_bitbucket_chart_path" {
+  description = "Path to local Helm charts to install local bitbucket software"
+  type        = string
+  default     = ""
+  validation {
+    condition     = can(regex("^[.?\\/?[a-zA-Z0-9|\\-|_]*]*$", var.local_bitbucket_chart_path))
+    error_message = "Invalid local Bitbucket Helm chart path."
+  }
+}
+
 variable "bitbucket_configuration" {
   description = "Bitbucket resource spec and chart version"
   type        = map(any)

--- a/modules/products/jira/helm.tf
+++ b/modules/products/jira/helm.tf
@@ -5,7 +5,7 @@ resource "helm_release" "jira" {
   name       = local.product_name
   namespace  = var.namespace
   repository = local.helm_chart_repository
-  chart      = local.product_name
+  chart      = local.jira_helm_chart_name
   version    = local.jira_helm_chart_version
   timeout    = var.installation_timeout * 60
 

--- a/modules/products/jira/locals.tf
+++ b/modules/products/jira/locals.tf
@@ -1,8 +1,10 @@
 locals {
   product_name = "jira"
 
-  helm_chart_repository   = "https://atlassian.github.io/data-center-helm-charts"
-  jira_helm_chart_version = var.jira_configuration["helm_version"]
+  use_local_chart         = fileexists("${var.local_jira_chart_path}/Chart.yaml")
+  helm_chart_repository   = local.use_local_chart ? null : "https://atlassian.github.io/data-center-helm-charts"
+  jira_helm_chart_name    = local.use_local_chart ? var.local_jira_chart_path : local.product_name
+  jira_helm_chart_version = local.use_local_chart ? null : var.jira_configuration["helm_version"]
 
   jira_software_resources = {
     "minHeap" : var.jira_configuration["min_heap"]

--- a/modules/products/jira/variables.tf
+++ b/modules/products/jira/variables.tf
@@ -75,6 +75,16 @@ variable "installation_timeout" {
   }
 }
 
+variable "local_jira_chart_path" {
+  description = "Path to local Helm charts to install local Jira software"
+  type        = string
+  default     = ""
+  validation {
+    condition     = can(regex("^[.?\\/?[a-zA-Z0-9|\\-|_]*]*$", var.local_jira_chart_path))
+    error_message = "Invalid local Jira Helm chart path."
+  }
+}
+
 variable "jira_configuration" {
   description = "Jira resource spec and chart version"
   type        = map(any)

--- a/test/unittest/bamboo_test.go
+++ b/test/unittest/bamboo_test.go
@@ -17,6 +17,7 @@ func TestBambooVariablesPopulatedWithValidValues(t *testing.T) {
 	bambooKey := "helm_release.bamboo"
 	terraform.RequirePlannedValuesMapKeyExists(t, plan, bambooKey)
 	bamboo := plan.ResourcePlannedValuesMap[bambooKey]
+	assert.NotNil(t, bamboo.AttributeValues["version"])
 	assert.Equal(t, "deployed", bamboo.AttributeValues["status"])
 	assert.Equal(t, "bamboo", bamboo.AttributeValues["chart"])
 	assert.Equal(t, float64(testTimeout*60), bamboo.AttributeValues["timeout"])
@@ -76,7 +77,7 @@ var BambooCorrectVariables = map[string]interface{}{
 	"dataset_url":          nil,
 	"installation_timeout": testTimeout,
 	"bamboo_configuration": map[string]interface{}{
-		"helm_version": "1.0.0",
+		"helm_version": "",
 		"cpu":          "1",
 		"mem":          "1Gi",
 		"min_heap":     "256m",

--- a/variables.tf
+++ b/variables.tf
@@ -131,7 +131,7 @@ variable "enable_https_ingress" {
 variable "jira_helm_chart_version" {
   description = "Version of Jira Helm chart"
   type        = string
-  default     = "1.5.0"
+  default     = ""
 }
 
 variable "jira_image_repository" {
@@ -308,6 +308,12 @@ variable "jira_shared_home_snapshot_id" {
   }
 }
 
+variable "jira_install_local_chart" {
+  description = "If true installs Jira using local Helm charts located in local_helm_charts_path"
+  default     = false
+  type        = bool
+}
+
 ################################################################################
 # Confluence variables
 ################################################################################
@@ -322,7 +328,7 @@ variable "confluence_license" {
 variable "confluence_helm_chart_version" {
   description = "Version of confluence Helm chart"
   type        = string
-  default     = "1.5.1"
+  default     = ""
 }
 
 variable "confluence_version_tag" {
@@ -542,7 +548,7 @@ variable "confluence_shared_home_snapshot_id" {
 variable "bitbucket_helm_chart_version" {
   description = "Version of Bitbucket Helm chart"
   type        = string
-  default     = "1.5.0"
+  default     = ""
 }
 
 variable "bitbucket_version_tag" {
@@ -769,6 +775,12 @@ variable "bitbucket_db_master_password" {
   }
 }
 
+variable "bitbucket_install_local_chart" {
+  description = "If true installs Bitbucket using local Helm charts located in local_helm_charts_path"
+  default     = false
+  type        = bool
+}
+
 ################################################################################
 # Bamboo Variables
 ################################################################################
@@ -817,14 +829,14 @@ variable "number_of_bamboo_agents" {
 
 variable "bamboo_helm_chart_version" {
   description = "Version of Bamboo Helm chart"
-  default     = "1.5.0"
+  default     = ""
   type        = string
 }
 
 variable "bamboo_agent_helm_chart_version" {
   description = "Version of Bamboo agent Helm chart"
   type        = string
-  default     = "1.5.0"
+  default     = ""
 }
 
 variable "bamboo_version_tag" {


### PR DESCRIPTION
This PR adds support of installing local Helm charts for Jira and Bitbucket (smth that is there for Confluence and Bamboo), as well as unsets defaults for Helm chart version. When Helm chart versions are explicitly set they need to be constantly updated. When no version is provided, helm_release resource will automatically use the latest. It'll still be possible to override helm chart version, i.e. existing behavior is unchanged.

## Checklist
- [x] I have successful end to end tests run (with & without domain)
- [x] I have added unit tests (if applicable)
- [ ] I have user documentation (if applicable)
