### PR TITLE
CLIP-1630: Add additional role to e2e tests

### DIFF
--- a/.github/workflows/e2e-test-no-domain.yaml
+++ b/.github/workflows/e2e-test-no-domain.yaml
@@ -22,6 +22,7 @@ jobs:
       AWS_DEFAULT_REGION: us-east-1
       AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
       AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+      AWS_ADDITIONAL_ROLE: ${{ secrets.AWS_ADDITIONAL_ROLE }}
       TF_VAR_bamboo_license: ${{ secrets.TF_VAR_BAMBOO_LICENSE }}
       TF_VAR_confluence_license: ${{ secrets.TF_VAR_CONFLUENCE_LICENSE }}
       TF_VAR_bitbucket_license: ${{ secrets.TF_VAR_BITBUCKET_LICENSE }}

--- a/.github/workflows/e2e-test-with-domain.yaml
+++ b/.github/workflows/e2e-test-with-domain.yaml
@@ -22,6 +22,7 @@ jobs:
       AWS_DEFAULT_REGION: us-east-1
       AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
       AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+      AWS_ADDITIONAL_ROLE: ${{ secrets.AWS_ADDITIONAL_ROLE }}
       TF_VAR_bamboo_license: ${{ secrets.TF_VAR_BAMBOO_LICENSE }}
       TF_VAR_confluence_license: ${{ secrets.TF_VAR_CONFLUENCE_LICENSE }}
       TF_VAR_bitbucket_license: ${{ secrets.TF_VAR_BITBUCKET_LICENSE }}

--- a/test/e2etest/helper.go
+++ b/test/e2etest/helper.go
@@ -44,6 +44,7 @@ type TestConfig struct {
 	EnvironmentName   string
 	ConfigPath        string
 	ResourceOwner     string
+	AdditionalRole    string
 	ConfluenceLicense string
 	BitbucketLicense  string
 	BambooLicense     string
@@ -153,12 +154,13 @@ func getPassword(productList []string, product string) string {
 	return password
 }
 
-func createConfig(t *testing.T, productList []string, useDomain bool) TestConfig {
+func createConfig(t *testing.T, productList []string, useDomain bool, additionalRole string) TestConfig {
 
 	testConfig := TestConfig{
 		AwsRegion:         GetAvailableRegion(t),
 		EnvironmentName:   EnvironmentName(),
 		ResourceOwner:     resourceOwner,
+		AdditionalRole:    additionalRole,
 		ConfluenceLicense: getLicense(productList, confluence),
 		BitbucketLicense:  getLicense(productList, bitbucket),
 		BambooLicense:     getLicense(productList, bamboo),
@@ -175,6 +177,7 @@ func createConfig(t *testing.T, productList []string, useDomain bool) TestConfig
 	// variables
 	vars := make(map[string]interface{})
 	vars["resource_owner"] = resourceOwner
+	vars["additional_role"] = testConfig.AdditionalRole
 	vars["environment_name"] = testConfig.EnvironmentName
 	vars["region"] = testConfig.AwsRegion
 	vars["products"] = products

--- a/test/e2etest/installer_test.go
+++ b/test/e2etest/installer_test.go
@@ -12,7 +12,8 @@ func TestInstaller(t *testing.T) {
 
 	productList := []string{jira, confluence, bamboo, bitbucket}
 	useDomain, _ := strconv.ParseBool(os.Getenv("USE_DOMAIN"))
-	testConfig := createConfig(t, productList, useDomain)
+	additionalRole := os.Getenv("AWS_ADDITIONAL_ROLE")
+	testConfig := createConfig(t, productList, useDomain, additionalRole)
 
 	// Schedule uninstall and cleanup the environment
 	// multiple defer statements are executed in LIFO(Last-In, First-Out)

--- a/test/e2etest/test-config.tfvars.tmpl
+++ b/test/e2etest/test-config.tfvars.tmpl
@@ -130,3 +130,16 @@ bitbucket_nfs_limits_cpu      = "0.25"
 bitbucket_nfs_limits_memory   = "256Mi"
 
 bitbucket_termination_grace_period = 0
+
+{{if .additional_role != ""}}
+# Enable access to additional role
+eks_additional_roles = [
+  {
+    rolearn  = "{{ .additional_role }}"
+    username = "additional_role"
+    groups = [
+      "system:masters"
+    ]
+  }
+]
+{{end}}

--- a/test/e2etest/test-config.tfvars.tmpl
+++ b/test/e2etest/test-config.tfvars.tmpl
@@ -131,7 +131,7 @@ bitbucket_nfs_limits_memory   = "256Mi"
 
 bitbucket_termination_grace_period = 0
 
-{{if .additional_role != ""}}
+{{if .additional_role }}
 # Enable access to additional role
 eks_additional_roles = [
   {

--- a/test/unittest/eks_test.go
+++ b/test/unittest/eks_test.go
@@ -42,11 +42,13 @@ func TestEksVariablesPopulatedWithValidValues(t *testing.T) {
 	instanceTypes := plan.RawPlan.Variables["instance_types"].Value
 	minClusterCapacity := plan.RawPlan.Variables["min_cluster_capacity"].Value
 	maxClusterCapacity := plan.RawPlan.Variables["max_cluster_capacity"].Value
+	additionalRoles := plan.RawPlan.Variables["additional_roles"].Value
 
 	assert.Equal(t, "dummy-cluster-name", clusterName)
 	assert.Equal(t, "dummy_vpc_id", vpcId)
 	assert.Equal(t, []interface{}{"subnet1", "subnet2"}, subnets)
 	assert.Equal(t, []interface{}{"instance_type1", "instance_type2"}, instanceTypes)
+	assert.Equal(t, []interface{}{map[string]interface{}{"rolearn": "dcdarn", "username": "additional_role", "groups": []interface{}{"system:masters"}}}, additionalRoles)
 	assert.Equal(t, "1", minClusterCapacity)
 	assert.Equal(t, "10", maxClusterCapacity)
 }

--- a/test/unittest/test_variables.go
+++ b/test/unittest/test_variables.go
@@ -47,7 +47,10 @@ var EksWithValidValues = map[string]interface{}{
 	"instance_types":       []string{"instance_type1", "instance_type2"},
 	"min_cluster_capacity": 1,
 	"max_cluster_capacity": 10,
-	"additional_roles":     []string{},
+	"additional_roles": []interface{}{map[string]interface{}{
+		"rolearn":  "dcdarn",
+		"username": "additional_role",
+		"groups":   []interface{}{"system:masters"}}},
 }
 
 var EksWithUnsupportedKinesisRegion = map[string]interface{}{
@@ -421,11 +424,11 @@ var ConfluenceInvalidVariables = map[string]interface{}{
 		"license_abc":  "dummy_license", //invalid var name
 	},
 	"synchrony_configuration": map[string]interface{}{
-		"cpu":          "1",
-		"mem":          "1Gi",
-		"min_heap":     "256m",
-		"max_heap":     "512m",
-		"unknown_var":  "dummy_license", //invalid var name
+		"cpu":         "1",
+		"mem":         "1Gi",
+		"min_heap":    "256m",
+		"max_heap":    "512m",
+		"unknown_var": "dummy_license", //invalid var name
 	},
 	"enable_synchrony":         false,
 	"db_snapshot_id":           "dummy-snapshot-id",


### PR DESCRIPTION
This PR adds Atlassian role defined by a secret in actions to [aws_auth_roles](https://github.com/atlassian-labs/data-center-terraform/blob/main/modules/AWS/eks/main.tf#L37) which makes it possible to get access to EKS clusters created by e2e iam user by assuming the role defined in the actions secret.

e2e https://github.com/atlassian-labs/data-center-terraform/actions/runs/3484569813/jobs/5829262631 (can't use the label since workflows are used from master)

## Checklist
- [ ] I have successful end to end tests run (with & without domain)
- [x] I have added unit tests (if applicable)
- [ ] I have user documentation (if applicable)
