### PR TITLE
CLIP-1633: Send slack notifications with build statuses

### DIFF
--- a/.github/workflows/e2e-test-no-domain.yaml
+++ b/.github/workflows/e2e-test-no-domain.yaml
@@ -22,6 +22,8 @@ jobs:
       AWS_DEFAULT_REGION: us-east-1
       AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
       AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+      SLACK_WEBHOOK_URL_ALERTS: ${{ secrets.SLACK_WEBHOOK_URL_ALERTS }}
+      SLACK_WEBHOOK_URL_NOTIFICATIONS: ${{ secrets.SLACK_WEBHOOK_URL_NOTIFICATIONS }}
       TF_VAR_bamboo_license: ${{ secrets.TF_VAR_BAMBOO_LICENSE }}
       TF_VAR_confluence_license: ${{ secrets.TF_VAR_CONFLUENCE_LICENSE }}
       TF_VAR_bitbucket_license: ${{ secrets.TF_VAR_BITBUCKET_LICENSE }}
@@ -92,3 +94,17 @@ jobs:
         with:
           name: e2e-test-artifacts
           path: test/e2etest/artifacts/
+
+      - name: Send slack notification
+        if: always()
+        run: |
+          export GITHUB_EVENT_NUMBER="${{ github.event.number}}"
+          export JOB_STATUS="${{ job.status }}"
+          export PULL_REQUEST_URL="${{ github.event.pull_request._links.html.href }}"
+          export PULL_REQUEST_TITLE="${{ github.event.pull_request.title }}"
+          export SLACK_WEBHOOK_URL=${SLACK_WEBHOOK_URL_NOTIFICATIONS}
+          scripts/send_slack_notifications.sh
+          if [[ ${JOB_STATUS} == "failure" ]]; then
+            export SLACK_WEBHOOK_URL=${SLACK_WEBHOOK_URL_ALERTS}
+            scripts/send_slack_notifications.sh
+          fi

--- a/.github/workflows/e2e-test-with-domain.yaml
+++ b/.github/workflows/e2e-test-with-domain.yaml
@@ -22,6 +22,8 @@ jobs:
       AWS_DEFAULT_REGION: us-east-1
       AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
       AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+      SLACK_WEBHOOK_URL_ALERTS: ${{ secrets.SLACK_WEBHOOK_URL_ALERTS }}
+      SLACK_WEBHOOK_URL_NOTIFICATIONS: ${{ secrets.SLACK_WEBHOOK_URL_NOTIFICATIONS }}
       TF_VAR_bamboo_license: ${{ secrets.TF_VAR_BAMBOO_LICENSE }}
       TF_VAR_confluence_license: ${{ secrets.TF_VAR_CONFLUENCE_LICENSE }}
       TF_VAR_bitbucket_license: ${{ secrets.TF_VAR_BITBUCKET_LICENSE }}
@@ -93,3 +95,17 @@ jobs:
         with:
           name: e2e-test-artifacts
           path: test/e2etest/artifacts/
+
+      - name: Send slack notification
+        if: always()
+        run: |
+          export GITHUB_EVENT_NUMBER="${{ github.event.number}}"
+          export JOB_STATUS="${{ job.status }}"
+          export PULL_REQUEST_URL="${{ github.event.pull_request._links.html.href }}"
+          export PULL_REQUEST_TITLE="${{ github.event.pull_request.title }}"
+          export SLACK_WEBHOOK_URL=${SLACK_WEBHOOK_URL_NOTIFICATIONS}
+          scripts/send_slack_notifications.sh
+          if [[ ${JOB_STATUS} == "failure" ]]; then
+            export SLACK_WEBHOOK_URL=${SLACK_WEBHOOK_URL_ALERTS}
+            scripts/send_slack_notifications.sh
+          fi

--- a/scripts/send_slack_notifications.sh
+++ b/scripts/send_slack_notifications.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+set -e
+
+COMMIT="<https://github.com/$GITHUB_REPOSITORY/commit/${GITHUB_SHA}|${GITHUB_SHA}>"
+SOURCE="branch: <https://github.com/$GITHUB_REPOSITORY/tree/${GITHUB_REF_NAME}|${GITHUB_REF_NAME}>"
+
+if [ ${GITHUB_EVENT_NAME} == "pull_request" ]; then
+  SOURCE="pr: <${PULL_REQUEST_URL}|${PULL_REQUEST_TITLE}>"
+  COMMIT="<https://github.com/${GITHUB_REPOSITORY}/pull/${GITHUB_EVENT_NUMBER}/commits/${GITHUB_SHA}|${GITHUB_SHA}>"
+fi
+
+if [[ ${JOB_STATUS} == "success" ]]; then
+  ICON=":white_check_mark:"
+  COLOR="#00cc00"
+elif [[ ${JOB_STATUS} == "failure" ]]; then
+  ICON=":red_circle:"
+  COLOR="#cc0000"
+else
+  # assume it's cancelled
+  ICON=":white_circle:"
+  COLOR="#808080"
+fi
+
+PAYLOAD="{\"attachments\": [{\"color\":\"${COLOR}\",\"blocks\":[{\"type\":\"section\",\"text\":{\"type\":\"mrkdwn\",\"text\":\"${ICON} Workflow <https://github.com/$GITHUB_REPOSITORY/actions/runs/${GITHUB_RUN_ID}|${GITHUB_WORKFLOW}> has completed with result: *${JOB_STATUS}*\n• commit: ${COMMIT}\n• ${SOURCE}\n• event: ${GITHUB_EVENT_NAME} \n• triggered by: ${GITHUB_ACTOR}\"}}]}]}"
+
+curl -s -X POST ${SLACK_WEBHOOK_URL} -H 'Content-type: application/json' -d "${PAYLOAD}"


### PR DESCRIPTION
The suggested script uses incoming webhooks (one per channel) as message delivery method. The information in the message is pretty straightforward - commit, author, event type, link to PR if this is a PR.

## Checklist
- [ ] I have successful end to end tests run (with & without domain)
- [ ] I have added unit tests (if applicable)
- [ ] I have user documentation (if applicable)
