### PR TITLE
CLIP-1727: Skip refresh when destroying

### DIFF
--- a/uninstall.sh
+++ b/uninstall.sh
@@ -118,7 +118,7 @@ destroy_infrastructure() {
     terraform -chdir="${ROOT_PATH}" init -no-color | tee -a "${LOG_FILE}"
   fi
   set +e
-  terraform -chdir="${ROOT_PATH}" destroy -auto-approve -no-color "${OVERRIDE_CONFIG_FILE}" | tee -a "${LOG_FILE}"
+  terraform -chdir="${ROOT_PATH}" destroy -auto-approve -refresh=false -no-color "${OVERRIDE_CONFIG_FILE}" | tee -a "${LOG_FILE}"
   if [ $? -eq 0 ]; then
     set -e
   else
@@ -173,7 +173,7 @@ destroy_tfstate() {
       if ! test -d ".terraform" ; then
         terraform -chdir="${TFSTATE_FOLDER}" init -no-color | tee -a "${LOG_FILE}"
       fi
-      terraform -chdir="${TFSTATE_FOLDER}" destroy -auto-approve -refresh=false -no-color "${OVERRIDE_CONFIG_FILE}" | tee -a "${LOG_FILE}"
+      terraform -chdir="${TFSTATE_FOLDER}" destroy -auto-approve -no-color "${OVERRIDE_CONFIG_FILE}" | tee -a "${LOG_FILE}"
       if [ $? -eq 0 ]; then
         set -e
         log "Cleaning all the terraform generated files."

--- a/uninstall.sh
+++ b/uninstall.sh
@@ -173,7 +173,7 @@ destroy_tfstate() {
       if ! test -d ".terraform" ; then
         terraform -chdir="${TFSTATE_FOLDER}" init -no-color | tee -a "${LOG_FILE}"
       fi
-      terraform -chdir="${TFSTATE_FOLDER}" destroy -auto-approve -no-color "${OVERRIDE_CONFIG_FILE}" | tee -a "${LOG_FILE}"
+      terraform -chdir="${TFSTATE_FOLDER}" destroy -auto-approve -refresh=false -no-color "${OVERRIDE_CONFIG_FILE}" | tee -a "${LOG_FILE}"
       if [ $? -eq 0 ]; then
         set -e
         log "Cleaning all the terraform generated files."


### PR DESCRIPTION
# Problem statement
`uninstall.sh` may fail to destroy infra if terraform apply has been unsuccessful:

```
module.base-infrastructure.module.eks.aws_autoscaling_group_tag.this["Name"]: Refreshing state... [id=eks-appNode-t3_xlarge-50c26268-ea57-5aee-4523-68f33af7dd71,Name]
Error: Unsupported attribute
on dc-infrastructure.tf line 142, in module "confluence":
142: ingress = module.base-infrastructure.ingress
├────────────────
│ module.base-infrastructure is object with 5 attributes
This object does not have an attribute named "ingress".
Error: Unsupported attribute
on modules/AWS/rds/locals.tf line 4, in locals:
4: db_jdbc_connection = "jdbc:postgresql://${module.db.db_instance_endpoint}/${var.product}"
├────────────────
│ module.db is object with 12 attributes
This object does not have an attribute named "db_instance_endpoint".
Releasing state lock. This may take a few moments...
2022-11-29 20:28:01 [ERROR] Failed to remove 'dcapt-product-small' infrastructure.
```
This is most likely caused by the fact that Terraform needs to re-evaluate non existing instances/modules (those that failed to be created). Since we have modules that depend on each other, it's sadly sometimes the case.

For example, the ingress error above must be caused by the fact that ingress module deployment has never been completed while we need it [here](https://github.com/atlassian-labs/data-center-terraform/blob/main/dc-infrastructure.tf#L146), though [output](https://github.com/atlassian-labs/data-center-terraform/blob/main/modules/common/outputs.tf#L21) never came back because of the apply failure.

The workaround is to skip refresh when running terraform destroy since re-designing the entire project may be an overkill.

See: https://github.com/hashicorp/terraform/issues/21096

With this change, Terraform skips refresh, as in [this workflow](https://github.com/atlassian-labs/data-center-terraform/actions/runs/3598520911/jobs/6061357334#step:11:5425).

## Checklist
- [x] I have successful end to end tests run (with & without domain)
- [ ] I have added unit tests (if applicable)
- [ ] I have user documentation (if applicable)
