### PR TITLE
CLIP-1729: Assume IAM role to configure  AWS credentials for tests

### DIFF
--- a/.github/workflows/e2e-test-no-domain.yaml
+++ b/.github/workflows/e2e-test-no-domain.yaml
@@ -41,6 +41,11 @@ jobs:
         with:
           ref: ${{ github.event.pull_request.head.sha }}
 
+      - name: Pin Kubectl version
+        uses: azure/setup-kubectl@v3.0
+        with:
+          version: 'v1.24.0'
+
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@master
         with:
@@ -48,16 +53,11 @@ jobs:
           role-to-assume: ${{ secrets.AWS_IAM_ROLE }}
           role-session-name: DCTerraformSession
 
-      - name: Pin Kubectl version
-        uses: azure/setup-kubectl@v3.0
-        with:
-          version: 'v1.24.0'
-      
       - name: Setup Go environment
         uses: actions/setup-go@v3
         with:
           go-version: '1.18'
-      
+
       - name: Setup Python environment
         uses: actions/setup-python@v4
         with:
@@ -65,7 +65,7 @@ jobs:
       - run: |
           python -m pip install --upgrade pip
           pip install boto3
-      
+
       - name: Setup dependencies
         id: setup-dependencies
         working-directory: test/
@@ -73,10 +73,10 @@ jobs:
           go version
           go get -v -t -d ./... && go mod tidy
           echo "exit_code=$?" >> $GITHUB_OUTPUT
-      
+
       - name: Create test output directory
         run: mkdir test/e2etest/artifacts
-      
+
       - name: Add private SSH key for Bitbucket tests
         uses: shimataro/ssh-key-action@v2
         with:
@@ -84,11 +84,11 @@ jobs:
           name: bitbucket-e2e # optional
           known_hosts: dummy-entry
           if_key_exists: fail # replace / ignore / fail; optional (defaults to fail)
-      
+
       - name: Add public SSH key for Bitbucket tests
         run: |
           echo ${{ secrets.BITBUCKET_E2E_TEST_PUB_SSH_KEY }} > /home/runner/.ssh/bitbucket-e2e.pub
-      
+
       - name: E2E Testing with no domain
         id: e2e-test
         working-directory: test/
@@ -98,14 +98,14 @@ jobs:
           mkdir -p ~/.aws
           echo -e "[default]\naws_access_key_id = ${AWS_ACCESS_KEY_ID}\naws_secret_access_key = ${AWS_SECRET_ACCESS_KEY}\naws_session_token = ${AWS_SESSION_TOKEN}" > ~/.aws/credentials
           go test ./e2etest -v -timeout 85m -run Installer | tee ./e2etest/artifacts/e2etest.log
-      
+
       - name: Upload test log files
         if: always()
         uses: actions/upload-artifact@v3.1.1
         with:
           name: e2e-test-artifacts
           path: test/e2etest/artifacts/
-      
+
       - name: Send slack notification
         if: always()
         run: |

--- a/.github/workflows/e2e-test-no-domain.yaml
+++ b/.github/workflows/e2e-test-no-domain.yaml
@@ -18,10 +18,11 @@ jobs:
     if: ${{ github.event.label.name == 'e2e' || github.event_name == 'push' || github.event_name == 'workflow_dispatch' || github.event_name == 'schedule' }}
     name: E2E Testing with no domain
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: read
     env:
       AWS_DEFAULT_REGION: us-east-1
-      AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-      AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
       SLACK_WEBHOOK_URL_ALERTS: ${{ secrets.SLACK_WEBHOOK_URL_ALERTS }}
       SLACK_WEBHOOK_URL_NOTIFICATIONS: ${{ secrets.SLACK_WEBHOOK_URL_NOTIFICATIONS }}
       AWS_ADDITIONAL_ROLE: ${{ secrets.AWS_ADDITIONAL_ROLE }}
@@ -40,16 +41,23 @@ jobs:
         with:
           ref: ${{ github.event.pull_request.head.sha }}
 
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@master
+        with:
+          aws-region: us-east-1
+          role-to-assume: ${{ secrets.AWS_IAM_ROLE }}
+          role-session-name: DCTerraformSession
+
       - name: Pin Kubectl version
         uses: azure/setup-kubectl@v3.0
         with:
           version: 'v1.24.0'
-
+      
       - name: Setup Go environment
         uses: actions/setup-go@v3
         with:
           go-version: '1.18'
-
+      
       - name: Setup Python environment
         uses: actions/setup-python@v4
         with:
@@ -57,7 +65,7 @@ jobs:
       - run: |
           python -m pip install --upgrade pip
           pip install boto3
-
+      
       - name: Setup dependencies
         id: setup-dependencies
         working-directory: test/
@@ -65,10 +73,10 @@ jobs:
           go version
           go get -v -t -d ./... && go mod tidy
           echo "exit_code=$?" >> $GITHUB_OUTPUT
-
+      
       - name: Create test output directory
         run: mkdir test/e2etest/artifacts
-
+      
       - name: Add private SSH key for Bitbucket tests
         uses: shimataro/ssh-key-action@v2
         with:
@@ -76,26 +84,28 @@ jobs:
           name: bitbucket-e2e # optional
           known_hosts: dummy-entry
           if_key_exists: fail # replace / ignore / fail; optional (defaults to fail)
-
+      
       - name: Add public SSH key for Bitbucket tests
         run: |
           echo ${{ secrets.BITBUCKET_E2E_TEST_PUB_SSH_KEY }} > /home/runner/.ssh/bitbucket-e2e.pub
-
+      
       - name: E2E Testing with no domain
         id: e2e-test
         working-directory: test/
         run: |
           set -o pipefail
-          aws configure set aws_access_key_id "$AWS_ACCESS_KEY_ID" --profile default && aws configure set aws_secret_access_key "$AWS_SECRET_ACCESS_KEY" --profile default && aws configure set region "$AWS_DEFAULT_REGION" --profile default
+          # boto3 ignores AWS creds env vars for some reason
+          mkdir -p ~/.aws
+          echo -e "[default]\naws_access_key_id = ${AWS_ACCESS_KEY_ID}\naws_secret_access_key = ${AWS_SECRET_ACCESS_KEY}\naws_session_token = ${AWS_SESSION_TOKEN}" > ~/.aws/credentials
           go test ./e2etest -v -timeout 85m -run Installer | tee ./e2etest/artifacts/e2etest.log
-
+      
       - name: Upload test log files
         if: always()
         uses: actions/upload-artifact@v3.1.1
         with:
           name: e2e-test-artifacts
           path: test/e2etest/artifacts/
-
+      
       - name: Send slack notification
         if: always()
         run: |

--- a/.github/workflows/e2e-test-with-domain.yaml
+++ b/.github/workflows/e2e-test-with-domain.yaml
@@ -20,8 +20,6 @@ jobs:
     runs-on: ubuntu-latest
     env:
       AWS_DEFAULT_REGION: us-east-1
-      AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-      AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
       SLACK_WEBHOOK_URL_ALERTS: ${{ secrets.SLACK_WEBHOOK_URL_ALERTS }}
       SLACK_WEBHOOK_URL_NOTIFICATIONS: ${{ secrets.SLACK_WEBHOOK_URL_NOTIFICATIONS }}
       AWS_ADDITIONAL_ROLE: ${{ secrets.AWS_ADDITIONAL_ROLE }}
@@ -39,6 +37,13 @@ jobs:
         uses: actions/checkout@v3
         with:
           ref: ${{ github.event.pull_request.head.sha }}
+
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@master
+        with:
+          aws-region: us-east-1
+          role-to-assume: ${{ secrets.AWS_IAM_ROLE }}
+          role-session-name: DCTerraformSession
 
       - name: Pin Kubectl version
         uses: azure/setup-kubectl@v2.0
@@ -87,7 +92,8 @@ jobs:
         run: |
           set -o pipefail
           # boto3 ignores AWS creds env vars for some reason
-          aws configure set aws_access_key_id "$AWS_ACCESS_KEY_ID" --profile default && aws configure set aws_secret_access_key "$AWS_SECRET_ACCESS_KEY" --profile default && aws configure set region "$AWS_DEFAULT_REGION" --profile default
+          mkdir -p ~/.aws
+          echo -e "[default]\naws_access_key_id = ${AWS_ACCESS_KEY_ID}\naws_secret_access_key = ${AWS_SECRET_ACCESS_KEY}\naws_session_token = ${AWS_SESSION_TOKEN}" > ~/.aws/credentials
           go test ./e2etest -v -timeout 85m -run Installer | tee ./e2etest/artifacts/e2etest.log
 
       - name: Upload test log files

--- a/.github/workflows/e2e-test-with-domain.yaml
+++ b/.github/workflows/e2e-test-with-domain.yaml
@@ -18,6 +18,9 @@ jobs:
     if: ${{ github.event.label.name == 'e2e' || github.event_name == 'push' || github.event_name == 'workflow_dispatch' || github.event_name == 'schedule' }}
     name: E2E Testing with domain
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: read
     env:
       AWS_DEFAULT_REGION: us-east-1
       SLACK_WEBHOOK_URL_ALERTS: ${{ secrets.SLACK_WEBHOOK_URL_ALERTS }}

--- a/aws_clean.py
+++ b/aws_clean.py
@@ -1,6 +1,7 @@
 import logging
 import sys
 from argparse import ArgumentParser
+import time
 from time import sleep
 import boto3
 from boto3.exceptions import Boto3Error

--- a/aws_clean.py
+++ b/aws_clean.py
@@ -1,7 +1,6 @@
 import logging
 import sys
 from argparse import ArgumentParser
-import time
 from time import sleep
 import boto3
 from boto3.exceptions import Boto3Error

--- a/test/e2etest/installer_test.go
+++ b/test/e2etest/installer_test.go
@@ -59,6 +59,7 @@ func runInstallScript(configPath string) {
 		Stderr: os.Stdout,
 		Dir:    "../../",
 	}
+
 	// run `cmd` in background
 	_ = cmd.Start()
 
@@ -84,15 +85,13 @@ func runUninstallScript(configPath string) {
 
 func gatherK8sLogs(testConfig TestConfig) {
 	printTestBanner("Gathering K8s logs and events from environment ", testConfig.EnvironmentName)
-	//kubeconfig := fmt.Sprintf("../../kubeconfig_atlas-%s-cluster", testConfig.EnvironmentName)
 
 	cmd := &exec.Cmd{
 		Path:   "collect_k8s_logs.sh",
 		Args:   []string{"collect_k8s_logs.sh", "atlas-" + testConfig.EnvironmentName + "-cluster", testConfig.AwsRegion},
 		Stdout: os.Stdout,
 		Stderr: os.Stdout,
-		//Env:    []string{"KUBECONFIG=" + kubeconfig},
-		Dir: "../../scripts",
+		Dir:    "../../scripts",
 	}
 
 	// run `cmd` in background


### PR DESCRIPTION
This PR adds an official [AWS action](https://github.com/aws-actions/configure-aws-credentials) to assume a role (saved in actions secrets)

Ran from a branch https://github.com/atlassian-labs/data-center-terraform/actions/runs/3722634095/jobs/6313620095 since workflows are retrieved from master only.

## Checklist
- [ ] I have successful end to end tests run (with & without domain)
- [ ] I have added unit tests (if applicable)
- [ ] I have user documentation (if applicable)
