### PR TITLE
CLIP-1749, CLIP-1744: Read engine_version from snapshot. Support Postgres 14

### DIFF
--- a/config.tfvars
+++ b/config.tfvars
@@ -168,7 +168,7 @@ jira_db_name = "jira"
 # If you want to restore the database from a snapshot, uncomment the following line and provide the snapshot identifier.
 # This will restore the database from the snapshot and will not create a new database.
 # The snapshot should be in the same AWS account and region as the environment to be deployed.
-# You must provide Jira license if you wish to retore the database from a snapshot.
+# You must provide Jira license if you wish to restore the database from a snapshot.
 # You must provide jira_db_master_username and jira_db_master_password that matches the ones in snapshot
 #jira_db_snapshot_id = "<DB_SNAPSHOT_ID>"
 #jira_license = "<LICENSE_KEY>"

--- a/docs/docs/userguide/configuration/BAMBOO_CONFIGURATION.md
+++ b/docs/docs/userguide/configuration/BAMBOO_CONFIGURATION.md
@@ -135,7 +135,7 @@ bamboo_db_major_engine_version = "13"
 
 !!! info "Supported DB versions"
 
-    Be sure to use a [DB engine version that is supported by Bamboo](https://confluence.atlassian.com/bamboo/supported-platforms-289276764.html#Supportedplatforms-Databases){.external} 
+    Be sure to use a [DB engine version that is supported by Bamboo](https://confluence.atlassian.com/bamboo/supported-platforms-289276764.html#Supportedplatforms-Databases){.external}
 
 ### Database Instance Class
 

--- a/docs/docs/userguide/configuration/BITBUCKET_CONFIGURATION.md
+++ b/docs/docs/userguide/configuration/BITBUCKET_CONFIGURATION.md
@@ -101,12 +101,16 @@ bitbucket_max_heap = "512m"
 `bitbucket_db_major_engine_version` sets the PostgeSQL engine version that will be used.
 
 ```terraform
-bitbucket_db_major_engine_version = "13" 
+bitbucket_db_major_engine_version = "14" 
 ```
 
 !!! info "Supported DB versions"
 
-    Be sure to use a [DB engine version that is supported by Bitbucket](https://confluence.atlassian.com/bitbucketserver/supported-platforms-776640981.html){.external} 
+    Be sure to use a [DB engine version that is supported by Bitbucket](https://confluence.atlassian.com/bitbucketserver/supported-platforms-776640981.html){.external}
+
+!!! info "Restore from snapshot"
+
+    This value is ignored if RDS snaphost is provided with `bitbucket_db_snapshot_id`.
 
 
 ### Database Instance Class

--- a/docs/docs/userguide/configuration/CONFLUENCE_CONFIGURATION.md
+++ b/docs/docs/userguide/configuration/CONFLUENCE_CONFIGURATION.md
@@ -101,12 +101,16 @@ confluence_collaborative_editing_enabled = true
 `confluence_db_major_engine_version` sets the PostgeSQL engine version that will be used.
 
 ```terraform
-confluence_db_major_engine_version = "11" 
+confluence_db_major_engine_version = "14" 
 ```
 
 !!! info "Supported DB versions"
 
     Be sure to use a [DB engine version that is supported by Confluence](https://confluence.atlassian.com/doc/supported-platforms-207488198.html#SupportedPlatforms-Databases){.external} 
+
+!!! info "Restore from snapshot"
+
+    This value is ignored if RDS snaphost is provided with `confluence_db_snapshot_id`.
 
 ### Database Instance Class
 

--- a/docs/docs/userguide/configuration/JIRA_CONFIGURATION.md
+++ b/docs/docs/userguide/configuration/JIRA_CONFIGURATION.md
@@ -90,12 +90,16 @@ jira_reserved_code_cache = "512m"
 `jira_db_major_engine_version` sets the PostgeSQL engine version that will be used.
 
 ```terraform
-jira_db_major_engine_version = "12" 
+jira_db_major_engine_version = "14" 
 ```
 
 !!! info "Supported DB versions"
 
-    Be sure to use a [DB engine version that is supported by Jira](https://confluence.atlassian.com/adminjiraserver/supported-platforms-938846830.html#Supportedplatforms-Databases){.external} 
+    Be sure to use a [DB engine version that is supported by Jira](https://confluence.atlassian.com/adminjiraserver/supported-platforms-938846830.html#Supportedplatforms-Databases){.external}
+
+!!! info "Restore from snapshot"
+
+    This value is ignored if RDS snaphost is provided with `jira_db_snapshot_id`.
 
 ### Database Instance Class
 

--- a/modules/AWS/rds/locals.tf
+++ b/modules/AWS/rds/locals.tf
@@ -10,7 +10,8 @@ locals {
       "10" = "10.19",
       "11" = "11.14",
       "12" = "12.9",
-      "13" = "13.7"
+      "13" = "13.7",
+      "14" = "14.5"
   }, var.major_engine_version, "11.14")
 
   family = lookup(
@@ -18,6 +19,10 @@ locals {
       "10" = "postgres10",
       "11" = "postgres11",
       "12" = "postgres12",
-      "13" = "postgres13"
+      "13" = "postgres13",
+      "14" = "postgres14"
   }, var.major_engine_version, "postgres11")
+
+  db_snapshot_engine_version       = var.snapshot_identifier != null ? data.aws_db_snapshot.confluence_db_snapshot[0].engine_version : null
+  db_snapshot_major_engine_version = var.snapshot_identifier != null ? element(split(".", data.aws_db_snapshot.confluence_db_snapshot[0].engine_version),0) : null
 }

--- a/modules/AWS/rds/main.tf
+++ b/modules/AWS/rds/main.tf
@@ -21,6 +21,12 @@ module "security_group" {
   ]
 }
 
+data "aws_db_snapshot" "confluence_db_snapshot" {
+  count                  = var.snapshot_identifier != null ? 1 : 0
+  db_snapshot_identifier = var.snapshot_identifier
+  most_recent            = true
+}
+
 module "db" {
   source                      = "terraform-aws-modules/rds/aws"
   version                     = "~> 5.1"
@@ -32,9 +38,9 @@ module "db" {
 
   # All available versions: https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/CHAP_PostgreSQL.html#PostgreSQL.Concepts
   engine                      = "postgres"
-  engine_version              = local.engine_version
+  engine_version              = var.snapshot_identifier != null ? local.db_snapshot_engine_version : local.engine_version
   family                      = local.family             # DB parameter group
-  major_engine_version        = var.major_engine_version # DB option group
+  major_engine_version        = var.snapshot_identifier != null ? local.db_snapshot_major_engine_version : var.major_engine_version # DB option group
   instance_class              = var.instance_class
 
   allocated_storage           = var.allocated_storage

--- a/modules/AWS/rds/variables.tf
+++ b/modules/AWS/rds/variables.tf
@@ -48,7 +48,7 @@ variable "vpc" {
 }
 
 variable "major_engine_version" {
-  description = "RDS Major engine version for the product."
+  description = "RDS Major engine version for the product. If RDS snapshot is provided, this value is ignored."
   default     = "11"
   type        = string
   validation {

--- a/modules/AWS/rds/variables.tf
+++ b/modules/AWS/rds/variables.tf
@@ -52,8 +52,8 @@ variable "major_engine_version" {
   default     = "11"
   type        = string
   validation {
-    condition     = contains(["10", "11", "12", "13"], var.major_engine_version)
-    error_message = "Invalid major engine version. Valid ranges are from 10 to 13 (integer)."
+    condition     = contains(["10", "11", "12", "13", "14"], var.major_engine_version)
+    error_message = "Invalid major engine version. Valid ranges are from 10 to 14 (integer)."
   }
 }
 

--- a/test/unittest/confluence_test.go
+++ b/test/unittest/confluence_test.go
@@ -27,12 +27,8 @@ func TestConfluenceVariablesPopulatedWithValidValues(t *testing.T) {
 	dbModuleKey := "module.database.module.db.module.db_instance.aws_db_instance.this[0]"
 	terraform.RequirePlannedValuesMapKeyExists(t, plan, dbModuleKey)
 	dbModule := plan.ResourcePlannedValuesMap[dbModuleKey]
-	assert.Equal(t, "dummy-snapshot-id", dbModule.AttributeValues["snapshot_identifier"])
 	assert.Equal(t, "dummyUsername", dbModule.AttributeValues["username"])
 	assert.Equal(t, "dummyPassword!", dbModule.AttributeValues["password"])
-
-	jobKey := "kubernetes_job.pre_install[0]" // if we have snapshot, we need to run the pre-install job as well
-	terraform.RequirePlannedValuesMapKeyExists(t, plan, jobKey)
 }
 
 func TestConfluenceVariablesPopulatedWithInvalidValues(t *testing.T) {
@@ -112,16 +108,15 @@ var ConfluenceCorrectVariables = map[string]interface{}{
 		"license":      "dummy_license",
 	},
 	"synchrony_configuration": map[string]interface{}{
-		"cpu":          "1",
-		"mem":          "1Gi",
-		"min_heap":     "512m",
-		"max_heap":     "1024m",
-		"stack_size":   "1024k",
+		"cpu":        "1",
+		"mem":        "1Gi",
+		"min_heap":   "512m",
+		"max_heap":   "1024m",
+		"stack_size": "1024k",
 	},
 	"enable_synchrony":         false,
-	"db_snapshot_id":           "dummy-snapshot-id",
 	"db_master_username":       "dummyUsername",
 	"db_master_password":       "dummyPassword!",
 	"db_snapshot_build_number": "1234",
-	 "termination_grace_period": 0,
+	"termination_grace_period": 0,
 }

--- a/test/unittest/database_test.go
+++ b/test/unittest/database_test.go
@@ -49,7 +49,6 @@ func TestDbVariablesPopulatedWithValidValues(t *testing.T) {
 
 	terraform.RequirePlannedValuesMapKeyExists(t, plan, "module.db.module.db_instance.aws_db_instance.this[0]")
 	planDbIdentifier := plan.ResourcePlannedValuesMap["module.db.module.db_instance.aws_db_instance.this[0]"].AttributeValues["identifier"]
-	planDbSnapshotIdentifier := plan.ResourcePlannedValuesMap["module.db.module.db_instance.aws_db_instance.this[0]"].AttributeValues["snapshot_identifier"]
 	planUserName := plan.ResourcePlannedValuesMap["module.db.module.db_instance.aws_db_instance.this[0]"].AttributeValues["username"]
 	planEngine := plan.ResourcePlannedValuesMap["module.db.module.db_instance.aws_db_instance.this[0]"].AttributeValues["engine"]
 	planDbName := plan.ResourcePlannedValuesMap["module.db.module.db_instance.aws_db_instance.this[0]"].AttributeValues["db_name"]
@@ -58,7 +57,6 @@ func TestDbVariablesPopulatedWithValidValues(t *testing.T) {
 	planIops := plan.ResourcePlannedValuesMap["module.db.module.db_instance.aws_db_instance.this[0]"].AttributeValues["iops"]
 	planApplyImmediately := plan.ResourcePlannedValuesMap["module.db.module.db_instance.aws_db_instance.this[0]"].AttributeValues["apply_immediately"]
 	assert.Equal(t, inputRdsInstanceId, planDbIdentifier)
-	assert.Equal(t, inputRdsSnapshotId, planDbSnapshotIdentifier)
 	assert.Equal(t, "postgres", planUserName)
 	assert.Equal(t, "postgres", planEngine)
 	assert.Equal(t, dbName, planDbName)
@@ -66,6 +64,16 @@ func TestDbVariablesPopulatedWithValidValues(t *testing.T) {
 	assert.EqualValues(t, inputAllocatedStorage, planAllocatedStorage)
 	assert.EqualValues(t, inputIops, planIops)
 	assert.EqualValues(t, true, planApplyImmediately)
+}
+
+func TestDbVariablesWithoutSnapshot(t *testing.T) {
+	t.Parallel()
+
+	tfOptions := GenerateTFOptions(DbValidVariable, t, databaseModule)
+
+	plan := terraform.InitAndPlanAndShowWithStruct(t, tfOptions)
+
+	assert.Nil(t, plan.ResourcePlannedValuesMap["module.db.module.db_instance.aws_db_instance.this[0]"].AttributeValues["snapshot_identifier"])
 }
 
 func TestDbPostgresVersionMap(t *testing.T) {

--- a/test/unittest/test_variables.go
+++ b/test/unittest/test_variables.go
@@ -238,7 +238,6 @@ var inputSubnets = []interface{}{"subnet1", "subnet2"}
 const inputSourceSgId = "dummy-source-sg"
 const inputProduct = "bamboo"
 const inputRdsInstanceId = "dummy-rds-instance-id"
-const inputRdsSnapshotId = "dummy-rds-snapshot-id"
 const inputInstanceClass = "dummy.instance.class"
 const inputAllocatedStorage = 100
 const inputIops = 1000
@@ -268,7 +267,6 @@ var DbValidVariable = map[string]interface{}{
 		"vpc_id":          inputVpcId,
 		"private_subnets": inputSubnets,
 	},
-	"snapshot_identifier": inputRdsSnapshotId,
 }
 
 var DbVariableWithDBMasterPassword = map[string]interface{}{
@@ -290,8 +288,7 @@ var DbVariableWithDBMasterPassword = map[string]interface{}{
 		"vpc_id":          inputVpcId,
 		"private_subnets": inputSubnets,
 	},
-	"snapshot_identifier": inputRdsSnapshotId,
-	"db_master_password":  masterPwd,
+	"db_master_password": masterPwd,
 }
 
 var DbInvalidVariable = map[string]interface{}{
@@ -332,8 +329,7 @@ var DbVariableWithInvalidDBMasterPassword = map[string]interface{}{
 		"vpc_id":          inputVpcId,
 		"private_subnets": inputSubnets,
 	},
-	"snapshot_identifier": inputRdsSnapshotId,
-	"db_master_password":  "123@",
+	"db_master_password": "123@",
 }
 
 // Ingress
@@ -506,7 +502,6 @@ var JiraCorrectVariables = map[string]interface{}{
 	},
 	"db_master_password": "dummy_password",
 	"db_master_username": "dummy_username",
-	"db_snapshot_id":     "dummy-rds-snapshot-id",
 
 	"termination_grace_period": 0,
 }


### PR DESCRIPTION
This PR forces Terraform to rely on engine_version from a db snapshot if defined rather than on supplied values in tfvars file. This will fix the issue when snapshot db version differs from the one in tfvars.

Tested locally by using a snapshot with 11.4 version and setting 13.4 in tfvars. The first apply was a success and 11.4 db was created, the second one said there were no changes, i.e. engine version values from tfvars are ignored if db snapshot is defined.

Writing a unit test is somewhat problematic since the actual version is read from a real snapshot. To the contrary, I had to remove db snapshot identifier from unit tests as I found no way to avoid reading data and using some mock that would make Terratest happy. However, the logic around supplying db snapshot hasn't been changed so it's safe not to check if snapshot identifier is in db attributes.

Also, all DC apps support Postgres 14, so it's allowed in variable validation block, and major version 14 is mapped to 14.5 which is the latest 14.x as of today.

## Checklist
- [x] I have successful end to end tests run (with & without domain)
- [x] I have added unit tests (if applicable)
- [ ] I have user documentation (if applicable)
