### PR TITLE
CLIP-17-52: Add NAT IP to whitelist_cidr

### DIFF
--- a/modules/AWS/ingress/locals.tf
+++ b/modules/AWS/ingress/locals.tf
@@ -4,7 +4,8 @@ locals {
   ingress_namespace = "ingress-nginx"
   domain_supplied   = var.ingress_domain != null ? true : false
   enable_https_ingress = var.enable_https_ingress
-
+  nat_ip_cidr            = var.load_balancer_access_ranges == ["0.0.0.0/0"] ? [] : formatlist("%s/32", var.vpc.nat_public_ips)
+  
   ssh_tcp_setting = var.enable_ssh_tcp ? yamlencode({
     tcp = {
       7999 : "atlassian/bitbucket:ssh"

--- a/modules/AWS/ingress/variables.tf
+++ b/modules/AWS/ingress/variables.tf
@@ -24,3 +24,8 @@ variable "load_balancer_access_ranges" {
     error_message = "Invalid CIDR. Valid format is a list of '<IPv4>/[0-32]' e.g: [\"10.0.0.0/18\"]."
   }
 }
+
+variable "vpc" {
+  description = "VPC module that hosts the products."
+  type        = any
+}

--- a/modules/AWS/vpc/outputs.tf
+++ b/modules/AWS/vpc/outputs.tf
@@ -23,3 +23,8 @@ output "public_subnets_cidr_blocks" {
   value       = module.vpc.public_subnets_cidr_blocks
   description = "VPC public subnet CIDR blocks"
 }
+
+output "nat_public_ips" {
+  value       = module.vpc.nat_public_ips
+  description = "List of allocation ID of Elastic IPs created for AWS NAT Gateway"
+}

--- a/modules/common/locals.tf
+++ b/modules/common/locals.tf
@@ -2,4 +2,5 @@ locals {
   vpc_name       = format("atlas-%s-vpc", var.environment_name)
   cluster_name   = format("atlas-%s-cluster", var.environment_name)
   ingress_domain = var.domain != null ? "${var.environment_name}.${var.domain}" : null
+  nat_ip_cidr    = var.whitelist_cidr == ["0.0.0.0/0"] ? [] : formatlist("%s/32", module.vpc.nat_public_ips)
 }

--- a/modules/common/locals.tf
+++ b/modules/common/locals.tf
@@ -2,5 +2,4 @@ locals {
   vpc_name       = format("atlas-%s-vpc", var.environment_name)
   cluster_name   = format("atlas-%s-cluster", var.environment_name)
   ingress_domain = var.domain != null ? "${var.environment_name}.${var.domain}" : null
-  nat_ip_cidr    = var.whitelist_cidr == ["0.0.0.0/0"] ? [] : formatlist("%s/32", module.vpc.nat_public_ips)
 }

--- a/modules/common/main.tf
+++ b/modules/common/main.tf
@@ -33,7 +33,7 @@ module "ingress" {
   # inputs
   ingress_domain              = local.ingress_domain
   enable_ssh_tcp              = var.enable_ssh_tcp
-  # we need to merge the list of cirds provided in config.tfvars with the list of nat elastic IPs
+  # we need to merge the list of cidrs provided in config.tfvars with the list of nat elastic IPs
   # to make sure ingresses are available when accessed from within pods and nodes of the cluster
   load_balancer_access_ranges = concat(var.whitelist_cidr, local.nat_ip_cidr)
   enable_https_ingress        = var.enable_https_ingress

--- a/modules/common/main.tf
+++ b/modules/common/main.tf
@@ -35,8 +35,9 @@ module "ingress" {
   enable_ssh_tcp              = var.enable_ssh_tcp
   # we need to merge the list of cidrs provided in config.tfvars with the list of nat elastic IPs
   # to make sure ingresses are available when accessed from within pods and nodes of the cluster
-  load_balancer_access_ranges = concat(var.whitelist_cidr, local.nat_ip_cidr)
+  load_balancer_access_ranges = var.whitelist_cidr
   enable_https_ingress        = var.enable_https_ingress
+  vpc                         = module.vpc
 }
 
 resource "kubernetes_namespace" "products" {

--- a/modules/common/main.tf
+++ b/modules/common/main.tf
@@ -33,6 +33,8 @@ module "ingress" {
   # inputs
   ingress_domain              = local.ingress_domain
   enable_ssh_tcp              = var.enable_ssh_tcp
+  # we need to merge the list of cirds provided in config.tfvars with the list of nat elastic IPs
+  # to make sure ingresses are available when accessed from within pods and nodes of the cluster
   load_balancer_access_ranges = concat(var.whitelist_cidr, local.nat_ip_cidr)
   enable_https_ingress        = var.enable_https_ingress
 }

--- a/modules/common/main.tf
+++ b/modules/common/main.tf
@@ -33,7 +33,7 @@ module "ingress" {
   # inputs
   ingress_domain              = local.ingress_domain
   enable_ssh_tcp              = var.enable_ssh_tcp
-  load_balancer_access_ranges = var.whitelist_cidr
+  load_balancer_access_ranges = concat(var.whitelist_cidr, local.nat_ip_cidr)
   enable_https_ingress        = var.enable_https_ingress
 }
 

--- a/test/unittest/ingress_test.go
+++ b/test/unittest/ingress_test.go
@@ -58,6 +58,9 @@ func TestIngressIsCreatedWithoutDomain(t *testing.T) {
 	t.Parallel()
 
 	tfOptions := GenerateTFOptions(map[string]interface{}{
+		"vpc": map[string]interface{}{
+			"nat_public_ips": []string{"1.1.1.1", "2.2.2.2"},
+		},
 		"load_balancer_access_ranges": []string{"0.0.0.0/0"},
 		"enable_https_ingress":        bool(false),
 	}, t, ingressModule)

--- a/test/unittest/ingress_test.go
+++ b/test/unittest/ingress_test.go
@@ -1,6 +1,7 @@
 package unittest
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/gruntwork-io/terratest/modules/terraform"
@@ -13,6 +14,9 @@ func TestIngressIsCreatedWithDomain(t *testing.T) {
 	t.Parallel()
 
 	tfOptions := GenerateTFOptions(map[string]interface{}{
+		"vpc": map[string]interface{}{
+			"nat_public_ips": []string{"1.1.1.1", "2.2.2.2"},
+		},
 		"ingress_domain":              "test.deplops.com",
 		"enable_ssh_tcp":              true,
 		"load_balancer_access_ranges": []string{"0.0.0.0/0"},
@@ -23,6 +27,11 @@ func TestIngressIsCreatedWithDomain(t *testing.T) {
 
 	// verify the input variable
 	assert.Equal(t, "test.deplops.com", plan.RawPlan.Variables["ingress_domain"].Value)
+
+	// verify NAT public IPs are in controller.service.loadBalancerSourceRanges values in helm_release
+	expectedCidrs := plan.ResourcePlannedValuesMap["helm_release.ingress"].AttributeValues["set"].([]interface{})
+	assert.Contains(t, fmt.Sprintf("%v", expectedCidrs[0]), "0.0.0.0/0,1.1.1.1/32,2.2.2.2/32")
+
 
 	// verify ingress is created
 	ingressKey := "helm_release.ingress"

--- a/test/unittest/test_variables.go
+++ b/test/unittest/test_variables.go
@@ -344,6 +344,9 @@ var IngressInvalidVariablesValue = map[string]interface{}{
 		"10.13.1.1/32",
 	},
 	"enable_https_ingress": bool(false),
+	"vpc": map[string]interface{}{
+		"nat_public_ips": []string{"1.1.1.1", "2.2.2.2"},
+	},
 }
 
 var IngressValidVariablesValue = map[string]interface{}{
@@ -352,6 +355,9 @@ var IngressValidVariablesValue = map[string]interface{}{
 		"10.13.1.1/32",
 	},
 	"enable_https_ingress": bool(false),
+	"vpc": map[string]interface{}{
+		"nat_public_ips": []string{"1.1.1.1", "2.2.2.2"},
+	},
 }
 
 // Bitbucket


### PR DESCRIPTION
This PR fixes an issue with Confluence being unable to reach Synchrony using ingress URL when `whitelist_cidr` restricts access to a particular range. Since private subnets use NAT, we need to silently add NAT EIP to whitelist_cird, unless it's all-permissive `0.0.0.0/0`

## Checklist
- [x] I have successful end to end tests run (with & without domain)
- [x] I have added unit tests (if applicable)
- [ ] I have user documentation (if applicable)
