### PR TITLE
CLIP-1771: Fix instance disk size

### DIFF
--- a/modules/AWS/eks/main.tf
+++ b/modules/AWS/eks/main.tf
@@ -6,6 +6,7 @@ module "nodegroup_launch_template" {
   region                          = var.region
   tags                            = var.tags
   instance_types                  = var.instance_types
+  instance_disk_size              = var.instance_disk_size
   osquery_secret_name             = var.osquery_secret_name
   osquery_secret_region           = local.osquery_secret_region
   osquery_env                     = var.osquery_env
@@ -51,7 +52,6 @@ module "eks" {
   # Managed node group defaults
   eks_managed_node_group_defaults = {
     ami_type  = local.ami_type
-    disk_size = var.instance_disk_size
   }
 
   # Self-managed node group. We explicitly disable automatic launch template creation

--- a/modules/AWS/eks/nodegroup_launch_template/main.tf
+++ b/modules/AWS/eks/nodegroup_launch_template/main.tf
@@ -6,6 +6,17 @@ resource "aws_launch_template" "nodegroup" {
   update_default_version = true
   user_data              = local.user_data
   instance_type          = var.instance_types[0]
+  
+  block_device_mappings {
+    device_name = "/dev/xvda"
+
+    ebs {
+      volume_size           = var.instance_disk_size
+      volume_type           = "gp2"
+      delete_on_termination = true
+    }
+  }
+
   tag_specifications {
     resource_type = "instance"
     tags = var.tags

--- a/modules/AWS/eks/nodegroup_launch_template/variables.tf
+++ b/modules/AWS/eks/nodegroup_launch_template/variables.tf
@@ -22,6 +22,11 @@ variable "instance_types" {
   type        = list(string)
 }
 
+variable "instance_disk_size" {
+  description = "Size of the disk attached to the cluster instance."
+  type        = number
+}
+
 variable "osquery_secret_name" {
   description = "Fleet enrollment secret name"
   type = string

--- a/test/e2etest/installer_test.go
+++ b/test/e2etest/installer_test.go
@@ -30,6 +30,7 @@ func TestInstaller(t *testing.T) {
 
 	clusterHealthTests(t, testConfig)
 	checkAGSAndEC2Tags(t, testConfig)
+	checkEbsVolumes(t, testConfig)
 
 	productUrls := terraform.OutputMap(t, &terraform.Options{TerraformDir: "../../"}, "product_urls")
 	synchronyUrl := terraform.Output(t, &terraform.Options{TerraformDir: "../../"}, "synchrony_url")


### PR DESCRIPTION
`disk_size` in node group settings is ignored if a custom launch template is used. Moving ebs config to launch tempalte.

Added an [e2e test](https://github.com/atlassian-labs/data-center-terraform/pull/303/files#diff-6afb0bd2b96fbd68692fc79175b6bc446cb66721bbe7f07fb693df9d57fc5bdfR54) to check the actual default EBS vol size (50Gi)

## Checklist
- [x] I have successful end to end tests run (with & without domain)
- [ ] I have added unit tests (if applicable)
- [ ] I have user documentation (if applicable)
