### PR TITLE
Call aws without absolute path

### DIFF
--- a/modules/AWS/eks/nodegroup_launch_template/locals.tf
+++ b/modules/AWS/eks/nodegroup_launch_template/locals.tf
@@ -1,5 +1,4 @@
 locals {
-  osquery_version = "5.7.0"
   # https://hello.atlassian.net/wiki/spaces/OBSERVABILITY/pages/140624694/Logging+pipeline+-+Sending+logs+to+Splunk#Kinesis-Stream-Details
   # e2e are deployed to almost a dozen of AWS regions, and we need to identify the closest available kinesis region.
   # If the region is found in any of the supported regions lists, it will be used as kinesis region in osquery flags.

--- a/modules/AWS/eks/nodegroup_launch_template/templates/osquery/osquery.sh.tpl
+++ b/modules/AWS/eks/nodegroup_launch_template/templates/osquery/osquery.sh.tpl
@@ -51,7 +51,7 @@ OSQUERY_SERVICE_ENV=ci
 OSQUERY_ENV=${env}
 EOF
 
-/usr/local/bin/aws --region ${osquery_secret_region} secretsmanager get-secret-value --secret-id arn:aws:secretsmanager:${osquery_secret_region}:${account_id}:secret:${osquery_secret_name} | jq -r '.SecretString' > /etc/osquery/fleet.enrollment_secret
+aws --region ${osquery_secret_region} secretsmanager get-secret-value --secret-id arn:aws:secretsmanager:${osquery_secret_region}:${account_id}:secret:${osquery_secret_name} | jq -r '.SecretString' > /etc/osquery/fleet.enrollment_secret
 
 # osquery doesn't work with auditd service
 service auditd stop

--- a/test/unittest/eks_test.go
+++ b/test/unittest/eks_test.go
@@ -171,7 +171,7 @@ func TestEksNodeLaunchTemplate(t *testing.T) {
 	userData, _ := base64.StdEncoding.DecodeString(fmt.Sprint(nodeGroupLaunchTemplate.AttributeValues["user_data"]))
 	// assert that modules/AWS/eks/nodegroup_launch_template/templates/userdata.sh.tpl makes it to user_data in launch template
 	// and contains aws command to retrieve osquery fleet enrolment secret
-	assert.True(t, strings.Contains(string(userData), "/usr/local/bin/aws --region"))
+	assert.True(t, strings.Contains(string(userData), "aws --region"))
 	// assert that aws region for aws cli is set to the current region when osquery_secret_region is undefined
 	assert.True(t, strings.Contains(string(userData), "--region us-east-1"))
 }

--- a/test/unittest/eks_test.go
+++ b/test/unittest/eks_test.go
@@ -175,7 +175,7 @@ func TestEksNodeLaunchTemplate(t *testing.T) {
 	// assert that aws region for aws cli is set to the current region when osquery_secret_region is undefined
 	assert.True(t, strings.Contains(string(userData), "--region us-east-1"))
 	// assert that the default osquery version makes it to the userdata in launch template
-	assert.True(t, strings.Contains(string(userData), "sudo yum install -y osquery-5.7.0"))
+	assert.True(t, strings.Contains(string(userData), "osquery-5.7.0"))
 }
 
 func TestKinesisRegionSelection(t *testing.T) {

--- a/test/unittest/eks_test.go
+++ b/test/unittest/eks_test.go
@@ -174,6 +174,8 @@ func TestEksNodeLaunchTemplate(t *testing.T) {
 	assert.True(t, strings.Contains(string(userData), "aws --region"))
 	// assert that aws region for aws cli is set to the current region when osquery_secret_region is undefined
 	assert.True(t, strings.Contains(string(userData), "--region us-east-1"))
+	// assert that the default osquery version makes it to the userdata in launch template
+	assert.True(t, strings.Contains(string(userData), "sudo yum install -y osquery-5.7.0"))
 }
 
 func TestKinesisRegionSelection(t *testing.T) {

--- a/variables.tf
+++ b/variables.tf
@@ -1008,7 +1008,7 @@ variable "osquery_env" {
 variable "osquery_version" {
   description = "Osquery version"
   type        = string
-  default     = "5.4.0"
+  default     = "5.7.0"
 }
 
 variable "kinesis_log_producers_role_arns" {


### PR DESCRIPTION
Something may have changed in the way aws cli is installed, and it's not available at /us/local/bin/aws anymore.

Also, a local var with osquery version was actually unused. This PR changes the default value in root level vars.

## Checklist
- [x] I have successful end to end tests run (with & without domain)
- [ ] I have added unit tests (if applicable)
- [ ] I have user documentation (if applicable)
