### PR TITLE
CLIP-1757: Update nfs helm chart appVersion

### DIFF
--- a/helm-charts/nfs-server/Chart.yaml
+++ b/helm-charts/nfs-server/Chart.yaml
@@ -4,4 +4,4 @@ description: A NFS server for testing purposes. Do not use in production.
 
 type: application
 version: 0.2.0
-appVersion: "2.0"
+appVersion: "2.1"


### PR DESCRIPTION
Use updated nfs server test image with ganesha v4.x - https://hub.docker.com/layers/atlassian/nfs-server-test/2.1/images/sha256-488817857d671ea209855d4187fb9cd45c39e22d3fb8b8cd97e95ec2e5246c37?context=explore

Previous 2.0 tag had issues which sometimes made Bitbucket scaling impossible. From time to time we see the following error when trying to scale Bitbucket:

```
2023-01-31 21:01:04,693 ERROR [spring-startup]  c.a.s.internal.home.HomeLockAcquirer Lock file /var/atlassian/application-data/shared-home/.lock cannot be obtained in home directory /var/atlassian/application-data/shared-home. Does bitbucket have write permission on that directory? Is file locking enabled for the filesystem?
```

NFS logs go as follows:

```
31/01/2023 21:01:04 : epoch 63d8bc49 : bitbucket-nfs-server-0 : nfs-ganesha-15[svc_3012] nsm_monitor :NLM :EVENT :Monitor ::ffff:10.0.0.143 SM_MON failed: RPC: Timed out
```
[Updating ganesha to v4](https://github.com/atlassian-forks/nfs-server-docker/pull/3/files#diff-dd2c0eb6ea5cfc6c4bd4eac30934e2d5746747af48fef6da689e85b752f39557R24) fixes the problem.

## Checklist
- [x] I have successful end to end tests run (with & without domain)
- [ ] I have added unit tests (if applicable)
- [ ] I have user documentation (if applicable)
