### PR TITLE
Remove unused variable passed to templates

### DIFF
--- a/modules/AWS/eks/nodegroup_launch_template/locals.tf
+++ b/modules/AWS/eks/nodegroup_launch_template/locals.tf
@@ -31,7 +31,6 @@ locals {
     osquery_version                 = var.osquery_version
     env                             = var.osquery_env
     aws_sts_arn_role                = local.aws_sts_arn_role
-    kinesis_log_producers_role_arns = var.kinesis_log_producers_role_arns
     })]
 
   user_data = local.user_content != null ? base64encode(join("\n",local.user_content)) : null


### PR DESCRIPTION
Template does not need this var, as the role arn is computed in locals and passed as `aws_sts_arn_role`.

## Checklist
- [x] I have successful end to end tests run (with & without domain)
- [ ] I have added unit tests (if applicable)
- [ ] I have user documentation (if applicable)
