### PR TITLE
CLIP-1779: Update EKS to 1.25

### DIFF
--- a/config.tfvars
+++ b/config.tfvars
@@ -13,7 +13,7 @@ environment_name = "<ENVIRONMENT>"
 # Cloud provider region that this configuration will deploy to.
 region = "<REGION>"
 
-# EKS K8S API version. Defaults to 1.24. Allowed values are from 1.21 to 1.24.
+# EKS K8S API version. Defaults to 1.25. Allowed values are from 1.21 to 1.25.
 # See: https://docs.aws.amazon.com/eks/latest/userguide/kubernetes-versions.html
 # eks_version = <EKS_VERSION>
 

--- a/modules/AWS/eks/locals.tf
+++ b/modules/AWS/eks/locals.tf
@@ -7,7 +7,7 @@ locals {
   autoscaler_service_account_namespace = "kube-system"
   autoscaler_service_account_name      = "cluster-autoscaler-aws-cluster-autoscaler-chart"
 
-  autoscaler_version = "9.16.0"
+  autoscaler_version = "9.25.0"
 
   ami_type = "AL2_x86_64"
 

--- a/modules/AWS/eks/variables.tf
+++ b/modules/AWS/eks/variables.tf
@@ -11,8 +11,8 @@ variable "eks_version" {
   description   = "EKS K8s version"
   type          = number
   validation {
-    condition     = can(regex("^1\\.2[1-4]", var.eks_version))
-    error_message = "Invalid EKS K8S version. Valid versions are from 1.21 to 1.24"
+    condition     = can(regex("^1\\.2[1-5]", var.eks_version))
+    error_message = "Invalid EKS K8S version. Valid versions are from 1.21 to 1.25"
   }
 }
 

--- a/modules/common/variables.tf
+++ b/modules/common/variables.tf
@@ -16,8 +16,8 @@ variable "eks_version" {
   description   = "EKS K8s version"
   type          = number
   validation {
-    condition     = can(regex("^1\\.2[1-4]", var.eks_version))
-    error_message = "Invalid EKS K8S version. Valid versions are from 1.21 to 1.24"
+    condition     = can(regex("^1\\.2[1-5]", var.eks_version))
+    error_message = "Invalid EKS K8S version. Valid versions are from 1.21 to 1.25"
   }
 }
 

--- a/modules/products/bitbucket/locals.tf
+++ b/modules/products/bitbucket/locals.tf
@@ -65,7 +65,7 @@ locals {
   # Elasticsearch
   elasticsearch_name                  = "elasticsearch"
   elasticsearch_helm_chart_repository = "https://helm.elastic.co"
-  elasticsearch_helm_chart_version    = "7.16.3"
+  elasticsearch_helm_chart_version    = "7.17.3"
   elasticsearch_antiAffinity          = "soft"
 
   elasticsearch_endpoint = var.elasticsearch_endpoint == null ? "http://${local.elasticsearch_name}-master:9200" : var.elasticsearch_endpoint

--- a/variables.tf
+++ b/variables.tf
@@ -24,10 +24,10 @@ variable "environment_name" {
 
 variable "eks_version" {
   description   = "EKS K8s version"
-  default       = 1.24
+  default       = 1.25
   type          = number
   validation {
-    condition     = can(regex("^1\\.2[1-4]", var.eks_version))
+    condition     = can(regex("^1\\.2[1-5]", var.eks_version))
     error_message = "Invalid EKS K8S version. Valid versions are from 1.21 to 1.24"
   }
 }


### PR DESCRIPTION
EKS 1.25 is available now while 1.21 has reached EOL ([proof](https://docs.aws.amazon.com/eks/latest/userguide/kubernetes-versions.html#kubernetes-release-calendar)). This PR bumps EKS version, as well as versions of 2 Helm charts that have PodDisruptionBudget in their templates. In 1.25 PDB has migrated from [policy/v1beta1 to policy/v1](https://kubernetes.io/docs/reference/using-api/deprecation-guide/#poddisruptionbudget-v125) which has been fixed in more recent Helm chart versions.

## Checklist
- [x] I have successful end to end tests run (with & without domain)
- [ ] I have added unit tests (if applicable)
- [ ] I have user documentation (if applicable)
