### PR TITLE
Update eks output

### DIFF
--- a/modules/AWS/eks/locals.tf
+++ b/modules/AWS/eks/locals.tf
@@ -1,8 +1,5 @@
 
 locals {
-  # When the framework get uninstalled, there is no appNode attribute for node_group and so next install will break
-  # because eks is still is not created but terraform tries to evaluate the cluster_asg_name
-  cluster_asg_name = try(module.eks.node_groups.appNodes.resources[0].autoscaling_groups[0].name, null)
 
   autoscaler_service_account_namespace = "kube-system"
   autoscaler_service_account_name      = "cluster-autoscaler-aws-cluster-autoscaler-chart"

--- a/modules/AWS/eks/outputs.tf
+++ b/modules/AWS/eks/outputs.tf
@@ -24,7 +24,7 @@ output "cluster_security_group" {
 }
 
 output "cluster_asg_name" {
-  value = local.cluster_asg_name
+  value = module.eks.eks_managed_node_groups_autoscaling_group_names[0]
 }
 
 output "availability_zone" {

--- a/outputs.tf
+++ b/outputs.tf
@@ -12,8 +12,7 @@ output "eks" {
   description = "EKS cluster information"
 
   value = {
-    cluster_name     = module.base-infrastructure.eks.cluster_name
-    cluster_id       = module.base-infrastructure.eks.cluster_id
+    cluster_name     = local.cluster_name
     cluster_asg_name = module.base-infrastructure.eks.cluster_asg_name
   }
 }

--- a/outputs.tf
+++ b/outputs.tf
@@ -8,12 +8,12 @@ output "vpc" {
   }
 }
 
-output "cluster_details" {
+output "eks" {
   description = "EKS cluster information"
 
   value = {
     cluster_name     = local.cluster_name
-    cluster_asg_name = module.base-infrastructure.eks.cluster_asg_name
+    cluster_asg_name = nonsensitive(module.base-infrastructure.eks.cluster_asg_name)
   }
 }
 

--- a/outputs.tf
+++ b/outputs.tf
@@ -8,7 +8,7 @@ output "vpc" {
   }
 }
 
-output "eks" {
+output "cluster_details" {
   description = "EKS cluster information"
 
   value = {

--- a/outputs.tf
+++ b/outputs.tf
@@ -13,7 +13,6 @@ output "eks" {
 
   value = {
     cluster_name     = local.cluster_name
-    cluster_asg_name = nonsensitive(module.base-infrastructure.eks.cluster_asg_name)
   }
 }
 


### PR DESCRIPTION
Fixing occasional error:

```
Error: Output refers to sensitive values
  on outputs.tf line 11:
  11: output "eks" {
To reduce the risk of accidentally exporting sensitive data that was intended
to be only internal, Terraform requires that any root module output
containing sensitive data be explicitly marked as sensitive, to confirm your
intent.
If you do intend to export this data, annotate the output value as sensitive
by adding the following argument:
    sensitive = true
```

Since cluster name is explicitly set, no need to get it from module's outputs. Also, removing asg name from outputs since it's not used.

## Checklist
- [x] I have successful end to end tests run (with & without domain)
- [ ] I have added unit tests (if applicable)
- [ ] I have user documentation (if applicable)
