### PR TITLE
Use name prefix for launch template. Delete IAM roles and policies

### DIFF
--- a/aws_clean.py
+++ b/aws_clean.py
@@ -417,6 +417,24 @@ def delete_iam_policies(service_name):
         client.delete_policy(PolicyArn=policy_arn)
 
 
+def delete_launch_templates(service_name, aws_region):
+    logging.info('Deleting launch templates')
+    client = boto3.client('ec2', region_name=aws_region)
+    response = client.describe_launch_templates(
+        Filters=[
+            {
+                'Name': 'tag:' + 'service_name',
+                'Values': [service_name]
+            }
+        ]
+    )
+    launch_templates = response['LaunchTemplates']
+    for launch_template in launch_templates:
+        template_id = launch_template['LaunchTemplateId']
+        print(f"Deleting Launch Template: {template_id}")
+        client.delete_launch_template(LaunchTemplateId=template_id)
+
+
 def main():
     parser = ArgumentParser()
     parser.add_argument("--service_name")
@@ -447,6 +465,7 @@ def main():
     terminate_open_id_providers(service_name)
     logging.info("Delete unused EBS volumes")
     delete_volumes(service_name, aws_region)
+    delete_launch_templates(service_name, aws_region)
     delete_certificates(service_name, aws_region)
     delete_hosted_zones(service_name)
     delete_iam_policies(service_name)

--- a/modules/AWS/eks/main.tf
+++ b/modules/AWS/eks/main.tf
@@ -1,5 +1,9 @@
 data "aws_caller_identity" "current" {}
 
+data "aws_launch_template" "nodes" {
+  id = module.nodegroup_launch_template.id
+}
+
 module "nodegroup_launch_template" {
   cluster_name                    = var.cluster_name
   source                          = "./nodegroup_launch_template"
@@ -66,7 +70,7 @@ module "eks" {
       subnet_ids               = slice(var.subnets, 0, 1)
       capacity_type            = "ON_DEMAND"
       create_launch_template   = false
-      launch_template_name     = "${var.cluster_name}-launch-template"
+      launch_template_name     = data.aws_launch_template.nodes.name
       launch_template_version  = module.nodegroup_launch_template.version
       create_iam_role          = false
       iam_role_arn             = aws_iam_role.node_group.arn

--- a/modules/AWS/eks/nodegroup_launch_template/main.tf
+++ b/modules/AWS/eks/nodegroup_launch_template/main.tf
@@ -1,7 +1,7 @@
 data "aws_caller_identity" "current" {}
 
 resource "aws_launch_template" "nodegroup" {
-  name                   = "${var.cluster_name}-launch-template"
+  name_prefix            = var.cluster_name
   description            = "${var.cluster_name} Nodegroup Launch Template"
   update_default_version = true
   user_data              = local.user_data


### PR DESCRIPTION
Changes in this PR:

* use `name_prefix` for launch template instead of a name (always good to use it to avoid already exist errors in cases when uninstall failed and the infra was cleaned up with some script)
* add delete iam roles and policies functions to AWS cleanup script
* add delete launch templates function to AWS cleanup script



## Checklist
- [x] I have successful end to end tests run (with & without domain)
- [ ] I have added unit tests (if applicable)
- [ ] I have user documentation (if applicable)
