### PR TITLE
Always do init during unistall.sh

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # Example docker command to run install script
 # docker run --env-file aws_envs \
-# -v "$PWD/.terraform:/data-center-terraform/.terraform \
+# -v "$PWD/.terraform:/data-center-terraform/.terraform" \
 # -v "$PWD/logs:/data-center-terraform/logs" \
 # -v "$PWD/config.tfvars:/data-center-terraform/config.tfvars" \
 # -it atlassianlabs/terraform ./install.sh -c config.tfvars
@@ -13,7 +13,7 @@
 
 # Example docker command to run uninstall script
 # docker run --env-file aws_envs \
-# -v "$PWD/.terraform:/data-center-terraform/.terraform \
+# -v "$PWD/.terraform:/data-center-terraform/.terraform" \
 # -v "$PWD/logs:/data-center-terraform/logs" \
 # -v "$PWD/config.tfvars:/data-center-terraform/config.tfvars" \
 # -it atlassianlabs/terraform ./uninstall.sh -t -c config.tfvars

--- a/Dockerfile
+++ b/Dockerfile
@@ -22,7 +22,8 @@
 # AWS_ACCESS_KEY_ID=123dsa321asd
 # AWS_SECRET_ACCESS_KEY=asd123asd123
 
-FROM ubuntu:22.04
+ARG BASE_IMAGE=ubuntu:22.04
+FROM $BASE_IMAGE
 
 RUN apt-get update \
     && apt-get install -y gnupg software-properties-common curl unzip \

--- a/uninstall.sh
+++ b/uninstall.sh
@@ -176,9 +176,8 @@ destroy_tfstate() {
             * ) log "Please answer 'Yes' to confirm deleting the terraform state." "ERROR"; exit 1;;
         esac
       fi
-      if ! test -d ".terraform" ; then
-        terraform -chdir="${TFSTATE_FOLDER}" init -no-color | tee -a "${LOG_FILE}"
-      fi
+      # always init as cluster could be in a broken state
+      terraform -chdir="${TFSTATE_FOLDER}" init -no-color | tee -a "${LOG_FILE}"
       terraform -chdir="${TFSTATE_FOLDER}" destroy -auto-approve -no-color "${OVERRIDE_CONFIG_FILE}" | tee -a "${LOG_FILE}"
       if [ $? -eq 0 ]; then
         set -e


### PR DESCRIPTION
As cluster could be in a broken state or in the case of Docker deployment modules folder is not exist and need to do init anyway.
