### PR TITLE
CLIP-1815: Crowd Helm release must depend on DB

### DIFF
--- a/modules/products/crowd/helm.tf
+++ b/modules/products/crowd/helm.tf
@@ -2,6 +2,7 @@
 
 resource "helm_release" "crowd" {
   depends_on = [
+    module.database,
     time_sleep.wait_crowd_termination
   ]
   name       = local.product_name


### PR DESCRIPTION
There are race conditions and often Crowd pod is up before the DB is ready.

## Checklist
- [x] I have successful end to end tests run (with & without domain)
- [ ] I have added unit tests (if applicable)
- [ ] I have user documentation (if applicable)
