### PR TITLE
Fix eks_additional_roles env var name

### DIFF
--- a/test/e2etest/helper.go
+++ b/test/e2etest/helper.go
@@ -45,7 +45,7 @@ type TestConfig struct {
 	EnvironmentName   string
 	ConfigPath        string
 	ResourceOwner     string
-	AdditionalRole    string
+	AdditionalRoles   string
 	ConfluenceLicense string
 	BitbucketLicense  string
 	BambooLicense     string
@@ -157,13 +157,13 @@ func getPassword(productList []string, product string) string {
 	return password
 }
 
-func createConfig(t *testing.T, productList []string, useDomain bool, additionalRole string) TestConfig {
+func createConfig(t *testing.T, productList []string, useDomain bool, additionalRoles string) TestConfig {
 
 	testConfig := TestConfig{
 		AwsRegion:         GetAvailableRegion(t),
 		EnvironmentName:   EnvironmentName(),
 		ResourceOwner:     resourceOwner,
-		AdditionalRole:    additionalRole,
+		AdditionalRoles:   additionalRoles,
 		ConfluenceLicense: getLicense(productList, confluence),
 		BitbucketLicense:  getLicense(productList, bitbucket),
 		BambooLicense:     getLicense(productList, bamboo),
@@ -182,7 +182,7 @@ func createConfig(t *testing.T, productList []string, useDomain bool, additional
 	// variables
 	vars := make(map[string]interface{})
 	vars["resource_owner"] = resourceOwner
-	vars["additional_role"] = testConfig.AdditionalRole
+	vars["eks_additional_roles"] = testConfig.AdditionalRoles
 	vars["environment_name"] = testConfig.EnvironmentName
 	vars["region"] = testConfig.AwsRegion
 	vars["products"] = products


### PR DESCRIPTION
The wrong env var was used in tests, as a result there was no way to login to e2e clusters to investigate issues.

https://github.com/atlassian-labs/data-center-terraform/blob/main/variables.tf#L132:
```
variable "eks_additional_roles" {
  description = "Additional roles that have access to the cluster."
  default     = []
  type        = list(object({ rolearn = string, username = string, groups = list(string) }))
}
```

Also, renamed test envs to indicate that it's a list.

## Checklist
- [ ] I have successful end to end tests run (with & without domain)
- [ ] I have added unit tests (if applicable)
- [ ] I have user documentation (if applicable)
