### PR TITLE
CLIP-1812: Pre-flight EBS/RDS checks

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -387,13 +387,13 @@ check_for_prerequisites
 # Process the arguments
 process_arguments
 
+# Verify the configuration file
+verify_configuration_file
+
 if [ ! -z "${PRE_FLIGHT_FLAG}" ]; then
   # verify snapshots if any
   pre_flight_checks
 fi
-
-# Verify the configuration file
-verify_configuration_file
 
 # Generates ./terraform-backend.tf and ./modules/tfstate/tfstate-local.tf
 generate_terraform_backend_variables


### PR DESCRIPTION
This PR adds a new optional flag (`-p`) and function that will check if RDS and EBS snapshots exist (and are public) and that they are compatible with the installed product version. The goal is not to let a user start creating infrastructure with RDS/EBS snapshots incompatible with the deployed product version.

How versions are being checked?

**EBS**
The check depends on the **EBS description** and it expects to find `dcapt-<product>-<version>` in the description. If the description does not contain `dcapt` the check will fail. The function will attempt to extract version from the description (replacing any `-` with `.`).

**RDS**

RDS snapshot **arn** is used to extract the version. The function expects that the arn contains `dcapt-<product>-<version>` pattern and will try to extract the version from it.

**Compatibility Rules**

The function will compare major.minor versions. For example:

* 7.19.2 is **compatible** with 7.19.9
* 7.18.2 is NOT **compatible** with 7.19.9
* 8.0.0 is **not compatible** with 7.19.9


## Checklist
- [ ] I have successful end to end tests run (with & without domain)
- [ ] I have added unit tests (if applicable)
- [ ] I have user documentation (if applicable)
