### PR TITLE
CLIP-1814: Remove S3 bucket and Dynamodb

### DIFF
--- a/uninstall.sh
+++ b/uninstall.sh
@@ -148,6 +148,7 @@ destroy_tfstate() {
     S3_BUCKET=$(get_variable "bucket_name" "${TF_STATE_FILE}")
     BUCKET_KEY=$(get_variable "bucket_key" "${TF_STATE_FILE}")
     DYNAMODB_TABLE=$(get_variable 'dynamodb_name' ${TF_STATE_FILE})
+    AWS_REGION=$(get_variable 'region' "${CONFIG_ABS_PATH}")
     local TFSTATE_FOLDER="${ROOT_PATH}/modules/tfstate"
     set +e
     aws s3api head-bucket --bucket "${S3_BUCKET}" 2>/dev/null
@@ -196,7 +197,7 @@ destroy_tfstate() {
       fi
 
       log "Deleting DynamoDB table ${DYNAMODB_TABLE}..."
-      aws dynamodb delete-table --table-name "${DYNAMODB_TABLE}" --region eu-north-1 >/dev/null
+      aws dynamodb delete-table --table-name "${DYNAMODB_TABLE}" --region "${AWS_REGION}" >/dev/null
       if [ $? -ne 0 ]; then
         ERROR="true"
       fi

--- a/uninstall.sh
+++ b/uninstall.sh
@@ -206,7 +206,7 @@ destroy_tfstate() {
         set -e
         log "Cleaning all the terraform generated files."
         bash "${SCRIPT_PATH}/cleanup.sh" -t -s -x -r ${ROOT_PATH}
-        log "Terraform state is removed successfully." "INFO"
+        log "Terraform state is removed successfully."
       else
         log "Couldn't destroy S3 bucket '${S3_BUCKET}' and/or dynamodb table '${DYNAMODB_TABLE}'. Terraform state '${BUCKET_KEY}' in S3 bucket '${S3_BUCKET}' cannot be removed." "ERROR"
         exit 1


### PR DESCRIPTION
Existing Terraform way of removing S3 bucket and DynamoDB does not work. Terraform says there's 0 resources to delete. In debug logs we see:
```
2023-08-02T18:01:20.788+1000 [DEBUG] pruneUnusedNodes: local.bucket_key (expand) is no longer needed, removing
2023-08-02T18:01:20.788+1000 [DEBUG] pruneUnusedNodes: module.tfstate-bucket.aws_s3_bucket.terraform_state (expand) is no longer needed, removing
2023-08-02T18:01:20.788+1000 [DEBUG] pruneUnusedNodes: module.tfstate-bucket.var.bucket_name (expand) is no longer needed, removing
2023-08-02T18:01:20.788+1000 [DEBUG] pruneUnusedNodes: module.tfstate-table.var.dynamodb_name (expand) is no longer needed, removing
2023-08-02T18:01:20.788+1000 [DEBUG] pruneUnusedNodes: module.tfstate-bucket.var.required_tags (expand) is no longer needed, removing
2023-08-02T18:01:20.788+1000 [DEBUG] pruneUnusedNodes: module.tfstate-bucket.aws_s3_bucket_logging.logging (expand) is no longer needed, removing
2023-08-02T18:01:20.788+1000 [DEBUG] pruneUnusedNodes: module.tfstate-bucket.data.aws_caller_identity.current (expand) is no longer needed, removing
2023-08-02T18:01:20.788+1000 [DEBUG] pruneUnusedNodes: module.tfstate-bucket.data.aws_region.current (expand) is no longer needed, removing
```
The resources are removed from state because the infrastructure was removed before that.

This PR replaces terraform destroy with aws cli commands to destroy S3 bucket and DynamoDB.

## Checklist
- [ ] I have successful end to end tests run (with & without domain)
- [ ] I have added unit tests (if applicable)
- [ ] I have user documentation (if applicable)
