### PR TITLE
CLIP-1832: Install the latest Terraform on runner container

### DIFF
--- a/.github/workflows/e2e-test-no-domain.yaml
+++ b/.github/workflows/e2e-test-no-domain.yaml
@@ -44,6 +44,18 @@ jobs:
         with:
           ref: ${{ github.event.pull_request.head.sha }}
 
+      - name: Install the latest Terraform
+        run: |
+          # check existing version
+          terraform -version
+          # download the latest
+          URL=$(curl -fsSL https://api.releases.hashicorp.com/v1/releases/terraform/latest | jq -r '.builds[] | select((.arch=="amd64") and (.os=="linux")).url')
+          curl -s -o /tmp/terraform.zip ${URL}
+          echo yes | unzip /tmp/terraform.zip -d /usr/local/bin/
+          rm /tmp/terraform.zip          
+          # check the latest version
+          terraform -version
+
       - name: Pin Kubectl version
         uses: azure/setup-kubectl@v3.0
         with:

--- a/.github/workflows/e2e-test-with-domain.yaml
+++ b/.github/workflows/e2e-test-with-domain.yaml
@@ -44,6 +44,18 @@ jobs:
         with:
           ref: ${{ github.event.pull_request.head.sha }}
 
+      - name: Install the latest Terraform
+        run: |
+          # check existing version
+          terraform -version
+          # download the latest
+          URL=$(curl -fsSL https://api.releases.hashicorp.com/v1/releases/terraform/latest | jq -r '.builds[] | select((.arch=="amd64") and (.os=="linux")).url')
+          curl -s -o /tmp/terraform.zip ${URL}
+          echo yes | unzip /tmp/terraform.zip -d /usr/local/bin/
+          rm /tmp/terraform.zip          
+          # check the latest version
+          terraform -version
+
       - name: Pin Kubectl version
         uses: azure/setup-kubectl@v2.0
         with:


### PR DESCRIPTION
## Pull request description

This PR added a step in e2e test to always fetch the latest Terrform version. The intention is to cover the time gap between new Terraform version release and Github Action runner base image update. 

It was initially surfaced from a [failed build](https://github.com/atlassian-labs/data-center-terraform/actions/runs/6594472245) where runner base image had Terraform 1.6.1 where the [bug](https://github.com/hashicorp/terraform/issues/34052) was introduced and Terraform crashed during the test. Issue been fixed in Terraform 1.6.2 but runner base image hasn't been updated in a timely manner. 


## Checklist
- [ ] I have successful end to end tests run (with & without domain)
- [ ] I have added unit tests (if applicable)
- [ ] I have user documentation (if applicable)
