### PR TITLE
CLIP-1840: Use a more recent security policy for https listener

### DIFF
--- a/modules/AWS/ingress/locals.tf
+++ b/modules/AWS/ingress/locals.tf
@@ -19,6 +19,7 @@ locals {
       service = {
         annotations = {
           "service.beta.kubernetes.io/aws-load-balancer-ssl-cert" : module.ingress_certificate[0].this_acm_certificate_arn
+          "service.beta.kubernetes.io/aws-load-balancer-ssl-negotiation-policy": "ELBSecurityPolicy-TLS-1-2-2017-01"
         }
       }
     }


### PR DESCRIPTION
The default policy is outdated. Let's use the most recent one available for a Classic LoadBalancer. e2e tests are happy.
