### PR TITLE
Use root path to locate license checker jar

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -127,10 +127,10 @@ pre_flight_checks() {
         log "Generate a new license at https://my.atlassian.com/" "ERROR"
         exit 1
       fi
-      if test -e "license-checker.jar"; then
+      if test -e "${ROOT_PATH}/license-checker.jar"; then
         export ATLASSIAN_PRODUCT="${PRODUCT}"
         export ATLASSIAN_LICENSE="${LICENSE_TEXT}"
-        java -jar license-checker.jar 2>&1 | while IFS= read -r line; do
+        java -jar "${ROOT_PATH}"/license-checker.jar 2>&1 | while IFS= read -r line; do
           log "$line" "INFO"
         done
         if [ $? -ne 0 ]; then


### PR DESCRIPTION
Without this, it will only work if the script is called from the directory where it's located.
