### PR TITLE
Sanitize PRODUCT when checking license

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -112,6 +112,9 @@ pre_flight_checks() {
 
   if [ "${SKIP_LICENSE_TEST_FLAG}" == "" ]; then
     for PRODUCT in ${PRODUCTS_ARRAY[@]}; do
+      # when config.tfvars has been edited in Windows, it may contain carriage returns `\r`
+      # which breaks the below code, so let's sanitize PRODUCT variable 
+      PRODUCT=$(echo ${PRODUCT} | sed 's/\r$//')
       log "Checking ${PRODUCT} license"
       LICENSE_ENV_VAR=${PRODUCT}'_license'
       LICENSE_TEXT=$(get_variable ${LICENSE_ENV_VAR} "${CONFIG_ABS_PATH}")


### PR DESCRIPTION
If config.tfvars has been edited in Windows, it may contain Win style carriage returns - \r. As a result, variable name becomes:

```
local $'variable_name=jira\r_license'
```

This PR adds sed to sanitize PRODUCT before using it in further code.

