### PR TITLE
Cleaned up Bamboo additional environment variable - ATL_BASE_URL

### DIFF
--- a/modules/products/bamboo/helm.tf
+++ b/modules/products/bamboo/helm.tf
@@ -64,7 +64,6 @@ resource "helm_release" "bamboo" {
         }
       }
     }),
-    local.additional_environment_settings,
     local.ingress_settings,
     local.context_path_settings,
     local.license_settings,

--- a/modules/products/bamboo/locals.tf
+++ b/modules/products/bamboo/locals.tf
@@ -39,18 +39,6 @@ locals {
     }
   })
 
-  # TODO: Once TFKUBE-384 has been merged and released this variable can be removed.
-  additional_environment_settings = !local.domain_supplied ? yamlencode({
-    bamboo = {
-      additionalEnvironmentVariables = [
-        {
-          name  = "ATL_BASE_URL"
-          value = "http://${var.ingress.outputs.lb_hostname}/${local.product_name}"
-        }
-      ]
-    }
-  }) : yamlencode({})
-
   context_path_settings = !local.domain_supplied ? yamlencode({
     bamboo = {
       service = {


### PR DESCRIPTION
## Pull request description

Cleaned up Bamboo additional environment variable - ATL_BASE_URL, since Helm chart already handles this for us. 

## Checklist
- [ ] I have successful end to end tests run (with & without domain)
- [ ] I have added unit tests (if applicable)
- [ ] I have user documentation (if applicable)
