### PR TITLE
CLIP-1848: Exit 0 if force uninstall has been successful

### DIFF
--- a/uninstall.sh
+++ b/uninstall.sh
@@ -136,6 +136,7 @@ destroy_infrastructure() {
     python3 <(curl -s https://raw.githubusercontent.com/atlassian/dc-app-performance-toolkit/master/app/util/k8s/terminate_cluster.py) \
             --cluster_name atlas-${ENVIRONMENT_NAME}-cluster \
             --aws_region ${REGION}
+    exit 0
   fi
 }
 


### PR DESCRIPTION
Just a little improvement to the uninstall logic. If normal terraform destroy failed for whatever reason, a force uninstall python  script runs. If it has successfully destroyed infra (including S3 bucket and DynamoDB table) there's no need to run `destroy_tfstate()` function as tf state does not exist and the function fails. Just exiting 0 will fix it.
