### PR TITLE
Upgrade kube-prom-stack to 56.6.2

### DIFF
--- a/modules/common/monitoring.tf
+++ b/modules/common/monitoring.tf
@@ -11,7 +11,7 @@ resource "helm_release" "prometheus_monitoring_stack" {
   name       = "prometheus"
   repository = "https://prometheus-community.github.io/helm-charts"
   chart      = "kube-prometheus-stack"
-  version    = "45.21.0"
+  version    = "56.6.2"
   timeout    = 600 # it takes a while to install this Helm chart
   namespace  = kubernetes_namespace.monitoring[count.index].metadata[0].name
 


### PR DESCRIPTION
This will install Grafana 10.3.1 with mitigated CVE-2023-4822 

## Checklist
- [x] I have successful end to end tests run (with & without domain)
