### PR TITLE
Add optional crowdstrike deployment to instance user data

### DIFF
--- a/.github/workflows/e2e-test-no-domain.yaml
+++ b/.github/workflows/e2e-test-no-domain.yaml
@@ -36,6 +36,9 @@ jobs:
       TF_VAR_kinesis_log_producers_role_arns: ${{ secrets.TF_VAR_KINESIS_LOG_PRODUCERS_ROLE_ARNS }}
       TF_VAR_osquery_fleet_enrollment_secret_name: ${{ secrets.TF_VAR_OSQUERY_FLEET_ENROLLMENT_SECRET_NAME }}
       TF_VAR_osquery_fleet_enrollment_host: ${{ secrets.TF_VAR_OSQUERY_FLEET_ENROLLMENT_HOST }}
+      TF_VAR_crowdstrike_secret_name: ${{ secrets.TF_VAR_CROWDSTRIKE_SECRET_NAME }}
+      TF_VAR_crowdstrike_kms_key_name: ${{ secrets.TF_VAR_CROWDSTRIKE_KMS_KEY_NAME }}
+      TF_VAR_crowdstrike_aws_account_id: ${{ secrets.TF_VAR_CROWDSTRIKE_AWS_ACCOUNT_ID }}
       USE_DOMAIN: "false"
 
     steps:

--- a/.github/workflows/e2e-test-with-domain.yaml
+++ b/.github/workflows/e2e-test-with-domain.yaml
@@ -36,6 +36,9 @@ jobs:
       TF_VAR_kinesis_log_producers_role_arns: ${{ secrets.TF_VAR_KINESIS_LOG_PRODUCERS_ROLE_ARNS }}
       TF_VAR_osquery_fleet_enrollment_secret_name: ${{ secrets.TF_VAR_OSQUERY_FLEET_ENROLLMENT_SECRET_NAME }}
       TF_VAR_osquery_fleet_enrollment_host: ${{ secrets.TF_VAR_OSQUERY_FLEET_ENROLLMENT_HOST }}
+      TF_VAR_crowdstrike_secret_name: ${{ secrets.TF_VAR_CROWDSTRIKE_SECRET_NAME }}
+      TF_VAR_crowdstrike_kms_key_name: ${{ secrets.TF_VAR_CROWDSTRIKE_KMS_KEY_NAME }}
+      TF_VAR_crowdstrike_aws_account_id: ${{ secrets.TF_VAR_CROWDSTRIKE_AWS_ACCOUNT_ID }}
       USE_DOMAIN: "true"
 
     steps:

--- a/config.tfvars
+++ b/config.tfvars
@@ -89,6 +89,22 @@ max_cluster_capacity = 5
 # snapshots_json_file_path = "test/dcapt-snapshots.json"
 
 ################################################################################
+# Crowdstrike settings. Atlassian only!
+################################################################################
+
+# name of the AWS secret holding cid and token
+# crowdstrike_secret_name = "crowdstrike-secret"
+
+# name of the kms key which is used to decrypt the secret
+# crowdstrike_kms_key_name = "kms-key"
+
+# AWS account that shares crowdstrike resources
+# crowdstrike_aws_account_id = "1234567890"
+
+# falcon sensor version  version
+# falcon_sensor_version = "7.10.0-16303"
+
+################################################################################
 # Osquery settings. Atlassian only!
 ################################################################################
 

--- a/dc-infrastructure.tf
+++ b/dc-infrastructure.tf
@@ -29,6 +29,11 @@ module "base-infrastructure" {
   kinesis_log_producers_role_arns = var.kinesis_log_producers_role_arns
   osquery_fleet_enrollment_host   = var.osquery_fleet_enrollment_host
 
+  crowdstrike_secret_name    = var.crowdstrike_secret_name
+  crowdstrike_kms_key_name   = var.crowdstrike_kms_key_name
+  crowdstrike_aws_account_id = var.crowdstrike_aws_account_id
+  falcon_sensor_version      = var.falcon_sensor_version
+
   confluence_s3_attachments_storage = var.confluence_s3_attachments_storage
 
   monitoring_enabled            = var.monitoring_enabled

--- a/locals.tf
+++ b/locals.tf
@@ -219,13 +219,13 @@ locals {
     bamboo     = null
   }
 
-  jira_rds_snapshot_id = length(compact(local.jira_rds_snapshot)) > 0 ? compact(local.jira_rds_snapshot)[0] : var.jira_db_snapshot_id != null ? var.jira_db_snapshot_id : null
-  jira_ebs_snapshot_id = length(compact(local.jira_ebs_snapshot)) > 0 ? compact(local.jira_ebs_snapshot)[0] : var.jira_shared_home_snapshot_id != null ? var.jira_shared_home_snapshot_id : null
+  jira_rds_snapshot_id        = length(compact(local.jira_rds_snapshot)) > 0 ? compact(local.jira_rds_snapshot)[0] : var.jira_db_snapshot_id != null ? var.jira_db_snapshot_id : null
+  jira_ebs_snapshot_id        = length(compact(local.jira_ebs_snapshot)) > 0 ? compact(local.jira_ebs_snapshot)[0] : var.jira_shared_home_snapshot_id != null ? var.jira_shared_home_snapshot_id : null
   jira_local_home_snapshot_id = length(compact(local.jira_local_home_snapshot)) > 0 ? compact(local.jira_local_home_snapshot)[0] : var.jira_local_home_snapshot_id != null ? var.jira_local_home_snapshot_id : null
-  
+
   confluence_rds_snapshot_id          = length(compact(local.confluence_rds_snapshot)) > 0 ? compact(local.confluence_rds_snapshot)[0] : var.confluence_db_snapshot_id != null ? var.confluence_db_snapshot_id : null
   confluence_ebs_snapshot_id          = length(compact(local.confluence_ebs_snapshot)) > 0 ? compact(local.confluence_ebs_snapshot)[0] : var.confluence_shared_home_snapshot_id != null ? var.confluence_shared_home_snapshot_id : null
-  confluence_local_home_snapshot_id = length(compact(local.confluence_local_home_snapshot)) > 0 ? compact(local.confluence_local_home_snapshot)[0] : var.confluence_local_home_snapshot_id != null ? var.confluence_local_home_snapshot_id : null
+  confluence_local_home_snapshot_id   = length(compact(local.confluence_local_home_snapshot)) > 0 ? compact(local.confluence_local_home_snapshot)[0] : var.confluence_local_home_snapshot_id != null ? var.confluence_local_home_snapshot_id : null
   confluence_db_snapshot_build_number = length(compact(local.confluence_build_numbers)) > 0 ? compact(local.confluence_build_numbers)[0] : var.confluence_db_snapshot_build_number != null ? var.confluence_db_snapshot_build_number : null
 
   crowd_rds_snapshot_id          = length(compact(local.crowd_rds_snapshot)) > 0 ? compact(local.crowd_rds_snapshot)[0] : var.crowd_db_snapshot_id != null ? var.crowd_db_snapshot_id : null

--- a/modules/AWS/eks/crowdstrike.tf
+++ b/modules/AWS/eks/crowdstrike.tf
@@ -1,0 +1,36 @@
+data "aws_iam_policy_document" "crowdstrike_s3" {
+  count = var.crowdstrike_secret_name != "" ? 1 : 0
+  statement {
+    effect    = "Allow"
+    actions   = ["s3:GetObject"]
+    resources = ["arn:aws:s3:::trust-shared-agents/*"]
+  }
+}
+
+resource "aws_iam_policy" "crowdstrike_s3" {
+  count       = var.crowdstrike_secret_name != "" ? 1 : 0
+  name        = "${var.cluster_name}_crowdstrike_s3"
+  description = "Allows accessing Crowdstrike S3 bucket to download rpm"
+  policy      = data.aws_iam_policy_document.crowdstrike_s3[count.index].json
+}
+
+data "aws_iam_policy_document" "crowdstrike_secret" {
+  count = var.crowdstrike_secret_name != "" ? 1 : 0
+  statement {
+    effect    = "Allow"
+    actions   = ["secretsmanager:GetSecretValue"]
+    resources = ["arn:aws:secretsmanager:*:${var.crowdstrike_aws_account_id}:secret:shared/*"]
+  }
+  statement {
+    effect    = "Allow"
+    actions   = ["kms:Decrypt"]
+    resources = ["arn:aws:kms:*:${var.crowdstrike_aws_account_id}:key/${var.crowdstrike_kms_key_name}"]
+  }
+}
+
+resource "aws_iam_policy" "crowdstrike_secret" {
+  count       = var.crowdstrike_secret_name != "" ? 1 : 0
+  name        = "${var.cluster_name}_crowdstrike_secret"
+  description = "Allows accessing Crowdstrike S3 bucket to download rpm"
+  policy      = data.aws_iam_policy_document.crowdstrike_secret[count.index].json
+}

--- a/modules/AWS/eks/iam.tf
+++ b/modules/AWS/eks/iam.tf
@@ -85,3 +85,15 @@ resource "aws_iam_role_policy_attachment" "fleet_enrollment_secret" {
   policy_arn = aws_iam_policy.fleet_enrollment_secret[0].arn
   role       = aws_iam_role.node_group.name
 }
+
+resource "aws_iam_role_policy_attachment" "crowdstrike_s3" {
+  count      = var.crowdstrike_secret_name != "" ? 1 : 0
+  policy_arn = aws_iam_policy.crowdstrike_s3[0].arn
+  role       = aws_iam_role.node_group.name
+}
+
+resource "aws_iam_role_policy_attachment" "crowdstrike_secret" {
+  count      = var.crowdstrike_secret_name != "" ? 1 : 0
+  policy_arn = aws_iam_policy.crowdstrike_secret[0].arn
+  role       = aws_iam_role.node_group.name
+}

--- a/modules/AWS/eks/main.tf
+++ b/modules/AWS/eks/main.tf
@@ -17,6 +17,9 @@ module "nodegroup_launch_template" {
   osquery_version                 = var.osquery_version
   kinesis_log_producers_role_arns = var.kinesis_log_producers_role_arns
   osquery_fleet_enrollment_host   = var.osquery_fleet_enrollment_host
+  crowdstrike_secret_name         = var.crowdstrike_secret_name
+  crowdstrike_aws_account_id      = var.crowdstrike_aws_account_id
+  falcon_sensor_version           = var.falcon_sensor_version
 }
 
 module "eks" {

--- a/modules/AWS/eks/nodegroup_launch_template/main.tf
+++ b/modules/AWS/eks/nodegroup_launch_template/main.tf
@@ -1,4 +1,5 @@
 data "aws_caller_identity" "current" {}
+data "aws_region" "current" {}
 
 resource "aws_launch_template" "nodegroup" {
   name_prefix            = var.cluster_name

--- a/modules/AWS/eks/nodegroup_launch_template/templates/crowdstrike/crowdstrike.sh.tpl
+++ b/modules/AWS/eks/nodegroup_launch_template/templates/crowdstrike/crowdstrike.sh.tpl
@@ -1,0 +1,46 @@
+--==MYBOUNDARY==
+Content-Type: text/x-shellscript; charset="us-ascii"
+
+#!/bin/bash
+
+### CROWDSTRIKE INSTALLATION
+
+sudo yum install -y yum-utils unzip jq
+curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip"
+unzip awscliv2.zip
+./aws/install
+
+# fetch falcon sensor rpm
+aws s3 cp s3://trust-shared-agents/crowdstrike/amazon/falcon-sensor-${falcon_sensor_version}.amzn2.x86_64.rpm .
+
+# install falcon sensor
+sudo yum install ./falcon-sensor-${falcon_sensor_version}.amzn2.x86_64.rpm -y
+
+# fetch a secret with cid and token
+crowdstrike_cid_and_token=$(aws secretsmanager get-secret-value \
+        --region "${aws_region}" \
+        --secret-id "arn:aws:secretsmanager:${aws_region}:${crowdstrike_aws_account_id}:secret:shared/${crowdstrike_secret_name}" \
+        --query SecretString \
+        --output text \
+        2>&1)
+
+crowdstrike_cid=$(echo "$${crowdstrike_cid_and_token}" | jq -r '.cid')
+crowdstrike_token=$(echo "$${crowdstrike_cid_and_token}" | jq -r '.token')
+
+# register agent to CrowdStrike console
+agent_tags="non-micros,non-micros/dev,non-micros/dev/dcapt"
+sudo /opt/CrowdStrike/falconctl -s -f --tags="$${agent_tags}" --cid="$${crowdstrike_cid}" --provisioning-token="$${crowdstrike_token}"
+
+sudo systemctl start falcon-sensor.service
+sudo systemctl enable falcon-sensor.service
+
+# verify crowdstrike is running 
+sudo yum list installed | grep falcon-sensor
+sudo systemctl is-active falcon-sensor
+sudo systemctl is-enabled falcon-sensor
+
+sudo lsmod | grep falcon
+ps -ef | grep falcon-sensor
+sudo netstat -tapn | grep falcon
+
+### END CROWDSTRIKE INSTALLATION

--- a/modules/AWS/eks/nodegroup_launch_template/templates/osquery/osquery.sh.tpl
+++ b/modules/AWS/eks/nodegroup_launch_template/templates/osquery/osquery.sh.tpl
@@ -58,4 +58,3 @@ systemctl status osqueryd.service
 
 ### /OSQUERY INSTALLATION
 
---==MYBOUNDARY==--

--- a/modules/AWS/eks/nodegroup_launch_template/variables.tf
+++ b/modules/AWS/eks/nodegroup_launch_template/variables.tf
@@ -58,3 +58,21 @@ variable "kinesis_log_producers_role_arns" {
     non-eu = string
   })
 }
+
+variable "crowdstrike_secret_name" {
+  description = "Crowdstrike secret name with cid and token"
+  type        = string
+  default     = ""
+}
+
+variable "crowdstrike_aws_account_id" {
+  description = "AWS account ID with a shareds crowdstrike secret"
+  type        = string
+  default     = ""
+}
+
+variable "falcon_sensor_version" {
+  description = "Falcon sensor version"
+  type        = string
+  default     = "7.10.0-16303"
+}

--- a/modules/AWS/eks/variables.tf
+++ b/modules/AWS/eks/variables.tf
@@ -121,6 +121,30 @@ variable "kinesis_log_producers_role_arns" {
   })
 }
 
+variable "crowdstrike_secret_name" {
+  description = "Crowdstrike secret name with cid and token"
+  type        = string
+  default     = ""
+}
+
+variable "crowdstrike_kms_key_name" {
+  description = "Crowdstrike kms key name to decrypt secret"
+  type        = string
+  default     = ""
+}
+
+variable "crowdstrike_aws_account_id" {
+  description = "AWS account ID with a shareds crowdstrike secret"
+  type        = string
+  default     = ""
+}
+
+variable "falcon_sensor_version" {
+  description = "Falcon sensor version"
+  type        = string
+  default     = "7.10.0-16303"
+}
+
 variable "namespace" {
   description = "Namespace for Atlassian products."
   type        = string

--- a/modules/common/main.tf
+++ b/modules/common/main.tf
@@ -29,6 +29,10 @@ module "eks" {
   kinesis_log_producers_role_arns   = var.kinesis_log_producers_role_arns
   confluence_s3_attachments_storage = var.confluence_s3_attachments_storage
   osquery_fleet_enrollment_host     = var.osquery_fleet_enrollment_host
+  crowdstrike_secret_name           = var.crowdstrike_secret_name
+  crowdstrike_kms_key_name          = var.crowdstrike_kms_key_name
+  crowdstrike_aws_account_id        = var.crowdstrike_aws_account_id
+  falcon_sensor_version             = var.falcon_sensor_version
 }
 
 

--- a/modules/common/variables.tf
+++ b/modules/common/variables.tf
@@ -139,6 +139,30 @@ variable "kinesis_log_producers_role_arns" {
   })
 }
 
+variable "crowdstrike_secret_name" {
+  description = "Crowdstrike secret name with cid and token"
+  type        = string
+  default     = ""
+}
+
+variable "crowdstrike_kms_key_name" {
+  description = "Crowdstrike kms key name to decrypt secret"
+  type        = string
+  default     = ""
+}
+
+variable "crowdstrike_aws_account_id" {
+  description = "AWS account ID with a shareds crowdstrike secret"
+  type        = string
+  default     = ""
+}
+
+variable "falcon_sensor_version" {
+  description = "Falcon sensor version"
+  type        = string
+  default     = "7.10.0-16303"
+}
+
 variable "confluence_s3_attachments_storage" {
   description = "Use S3 as attachment storage"
   type        = bool

--- a/modules/products/confluence/locals.tf
+++ b/modules/products/confluence/locals.tf
@@ -92,7 +92,7 @@ locals {
         },
         {
           name = "ATL_FORCE_CFG_UPDATE",
-          value: local.overwrite_cfg_xml
+          value : local.overwrite_cfg_xml
         },
       ]
     }

--- a/modules/products/jira/helm.tf
+++ b/modules/products/jira/helm.tf
@@ -40,8 +40,8 @@ resource "helm_release" "jira" {
             }
           }
         }
-        additionalJvmArgs = concat(local.ignore_index_check, local.reuse_old_index_snapshot, local.dcapt_analytics_property, var.additional_jvm_args)
-        additionalEnvironmentVariables = var.local_home_snapshot_id != null ? [{name = "ATL_FORCE_CFG_UPDATE", value: "true" }] : null
+        additionalJvmArgs              = concat(local.ignore_index_check, local.reuse_old_index_snapshot, local.dcapt_analytics_property, var.additional_jvm_args)
+        additionalEnvironmentVariables = var.local_home_snapshot_id != null ? [{ name = "ATL_FORCE_CFG_UPDATE", value : "true" }] : null
       }
       database = {
         type   = "postgres72"

--- a/test/e2etest/installer_test.go
+++ b/test/e2etest/installer_test.go
@@ -31,6 +31,7 @@ func TestInstaller(t *testing.T) {
 	clusterHealthTests(t, testConfig)
 	checkAGSAndEC2Tags(t, testConfig)
 	checkEbsVolumes(t, testConfig)
+	checkLaunchTemplate(t, testConfig)
 
 	productUrls := terraform.OutputMap(t, &terraform.Options{TerraformDir: "../../"}, "product_urls")
 	crowdDbInfo := terraform.OutputMap(t, &terraform.Options{TerraformDir: "../../"}, "crowd_database")

--- a/variables.tf
+++ b/variables.tf
@@ -1287,6 +1287,32 @@ variable "kinesis_log_producers_role_arns" {
   }
 }
 
+# Crowdstrike settings
+
+variable "crowdstrike_secret_name" {
+  description = "Crowdstrike secret name with cid and token"
+  type        = string
+  default     = ""
+}
+
+variable "crowdstrike_kms_key_name" {
+  description = "Crowdstrike kms key name to decrypt secret"
+  type        = string
+  default     = ""
+}
+
+variable "crowdstrike_aws_account_id" {
+  description = "AWS account ID with a shareds crowdstrike secret"
+  type        = string
+  default     = ""
+}
+
+variable "falcon_sensor_version" {
+  description = "Falcon sensor version"
+  type        = string
+  default     = "7.10.0-16303"
+}
+
 ################################################################################
 # Crowd Settings
 ################################################################################


### PR DESCRIPTION
This PR adds an optional crowdstrike installation to a user data script (that is executed after the ec2 instance starts). 

Defining `crowdstrike_secret_name` enables crowdstrike installation. There are other obligatory variables:

```
# name of the AWS secret holding cid and token
# crowdstrike_secret_name = "crowdstrike-secret"

# name of the kms key which is used to decrypt the secret
# crowdstrike_kms_key_name = "kms-key"

# AWS account that shares crowdstrike resources
# crowdstrike_aws_account_id = "1234567890"
```
How the script works:
* falcon sensor binaries is fetches from a pre-defined s3 bucket
* cid and token are fetched from SecretsManager
* crowdstrike is configured and started


## Checklist
- [x] I have successful end to end tests run (with & without domain)