### PR TITLE
Make scaling test more flexible

### DIFF
--- a/test/e2etest/cluster_test.go
+++ b/test/e2etest/cluster_test.go
@@ -23,7 +23,7 @@ func clusterHealthTests(t *testing.T, testConfig TestConfig) {
 	assert.NoError(t, err)
 	assert.Contains(t, output, "1 available")
 
-	assert.Equal(t, expectedNumberOfNodes, len(nodes), "Expected 2 nodes in the cluster")
+	assert.GreaterOrEqual(t, expectedNumberOfNodes, len(nodes), "Expected at least 2 nodes in the cluster")
 }
 
 func checkAGSAndEC2Tags(t *testing.T, testConfig TestConfig) {


### PR DESCRIPTION
Sometimes cluster is scaled to 3 nodes.
