### PR TITLE
DCCLIP-912: Added OpenSearch helm release resource to Confluence module

### DIFF
--- a/config.tfvars
+++ b/config.tfvars
@@ -406,6 +406,11 @@ confluence_collaborative_editing_enabled = true
 # Terraform will automatically create S3 bucket, IAM role and policy
 #confluence_s3_attachments_storage = true
 
+# Enable OpenSearch as Confluence search engine and configure resource requests and limits
+# confluence_opensearch_enabled = false
+# confluence_opensearch_requests_cpu = "<REQUESTS_CPU>"
+# confluence_opensearch_requests_memory = "<REQUESTS_MEMORY>"
+
 ################################################################################
 # Bitbucket Settings
 ################################################################################

--- a/dc-infrastructure.tf
+++ b/dc-infrastructure.tf
@@ -242,6 +242,8 @@ module "confluence" {
 
   # If local Helm charts path is provided, Terraform will then install using local charts and ignores remote registry
   local_confluence_chart_path = local.local_confluence_chart_path
+
+  opensearch_enabled = var.confluence_opensearch_enabled
 }
 
 module "bitbucket" {

--- a/dc-infrastructure.tf
+++ b/dc-infrastructure.tf
@@ -244,6 +244,8 @@ module "confluence" {
   local_confluence_chart_path = local.local_confluence_chart_path
 
   opensearch_enabled = var.confluence_opensearch_enabled
+  opensearch_requests_cpu = var.confluence_opensearch_requests_cpu
+  opensearch_requests_memory = var.confluence_opensearch_requests_memory
 }
 
 module "bitbucket" {

--- a/docs/docs/userguide/configuration/CONFLUENCE_CONFIGURATION.md
+++ b/docs/docs/userguide/configuration/CONFLUENCE_CONFIGURATION.md
@@ -242,3 +242,20 @@ confluence_shared_home_snapshot_id = "<SHARED_HOME_EBS_SNAPSHOT_IDENTIFIER>"
 ```
 
 ??? Warning "Snapshot and your environment must be in same region"  
+
+## Search engine configuration
+### OpenSearch 
+`confluence_opensearch_enabled` decides whether to use OpenSearch as Confluence search engine. If set to true, 
+a single-node OpenSearch will be created as part of the deployment, and Confluence will be configured to connect to this instance. 
+
+```terraform
+confluence_opensearch_enabled = true
+```
+
+### OpenSearch instance resource configuration
+The following variables set number of CPU and amount of memory of OpenSearch instance. (Used default values as example.)
+
+```terraform
+confluence_opensearch_requests_cpu = "1"
+confluence_opensearch_requests_memory = "1Gi"
+```

--- a/modules/products/confluence/helm.tf
+++ b/modules/products/confluence/helm.tf
@@ -5,7 +5,8 @@ resource "helm_release" "confluence" {
   depends_on = [
     kubernetes_job.pre_install,
     kubernetes_persistent_volume_claim.local_home,
-    time_sleep.wait_confluence_termination
+    time_sleep.wait_confluence_termination,
+    helm_release.opensearch,
   ]
   name       = local.product_name
   namespace  = var.namespace
@@ -37,7 +38,7 @@ resource "helm_release" "confluence" {
             }
           }
         }
-        additionalJvmArgs = concat(local.dcapt_analytics_property, local.irsa_properties, var.additional_jvm_args)
+        additionalJvmArgs = concat(local.dcapt_analytics_property, local.irsa_properties, var.additional_jvm_args, local.opensearch_properties)
       }
       synchrony = {
         resources = {

--- a/modules/products/confluence/locals.tf
+++ b/modules/products/confluence/locals.tf
@@ -112,6 +112,12 @@ locals {
     "-Dconfluence.filestore.attachments.s3.bucket.name=${var.eks.confluence_s3_bucket_name}",
   "-Dconfluence.filestore.attachments.s3.bucket.region=${var.region_name}"] : []
 
+  opensearch_password = "OpenSearchAtl1234!"
+  opensearch_properties = var.opensearch_enabled ? ["-Dsearch.platform=opensearch",
+                           "-Dopensearch.http.url=http://opensearch-cluster-master.${var.namespace}.svc.cluster.local:9200",
+                           "-Dopensearch.password=${local.opensearch_password}",
+                           "-Dopensearch.username=admin"] : []
+
   service_account_annotations = var.confluence_s3_attachments_storage ? yamlencode({
     serviceAccount = {
       annotations = {

--- a/modules/products/confluence/opensearch.tf
+++ b/modules/products/confluence/opensearch.tf
@@ -1,0 +1,29 @@
+# Create the elasticsearch based on Elasticsearch Helm charts (https://github.com/elastic/helm-charts/tree/main/elasticsearch)
+
+resource "helm_release" "opensearch" {
+  count = var.opensearch_enabled ? 1 : 0
+
+  name       = "opensearch-${var.environment_name}"
+  namespace  = var.namespace
+  repository = "https://opensearch-project.github.io/helm-charts/"
+  chart      = "opensearch"
+#  version    = local.elasticsearch_helm_chart_version
+
+  values = [
+    yamlencode({
+      singleNode = true
+
+      extraEnvs = [
+        { name = "OPENSEARCH_INITIAL_ADMIN_PASSWORD", value = local.opensearch_password },
+        { name = "plugins.security.ssl.http.enabled", value = "false" }
+      ]
+
+      resources = {
+        requests = {
+          cpu    = var.opensearch_requests_cpu
+          memory = var.opensearch_requests_memory
+        }
+      }
+    })
+  ]
+}

--- a/modules/products/confluence/variables.tf
+++ b/modules/products/confluence/variables.tf
@@ -176,3 +176,21 @@ variable "additional_jvm_args" {
   description = "List of additional JVM arguments to be passed to the server"
   type        = list(string)
 }
+
+variable "opensearch_enabled" {
+  description = "If true, OpenSearch will be enabled."
+  type        = bool
+  default     = false
+}
+
+variable "opensearch_requests_cpu" {
+  description = "The minimum CPU compute to request for the OpenSearch instance"
+  type        = string
+  default     = "1"
+}
+
+variable "opensearch_requests_memory" {
+  description = "The minimum amount of memory to allocate to the OpenSearch instance"
+  type        = string
+  default     = "1Gi"
+}

--- a/test/unittest/confluence_test.go
+++ b/test/unittest/confluence_test.go
@@ -1,7 +1,6 @@
 package unittest
 
 import (
-	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -31,7 +30,7 @@ func TestConfluenceVariablesPopulatedWithValidValues(t *testing.T) {
 	assert.Equal(t, "https://opensearch-project.github.io/helm-charts/", opensearch.AttributeValues["repository"])
 
 	values := opensearch.AttributeValues["values"].([]interface{})[0].(string)
-	expectedHelmValues := fmt.Sprintf("\"extraEnvs\":\n- \"name\": \"OPENSEARCH_INITIAL_ADMIN_PASSWORD\"\n  \"value\": \"OpenSearchAtl1234!\"\n- \"name\": \"plugins.security.ssl.http.enabled\"\n  \"value\": \"false\"\n\"resources\":\n  \"requests\":\n    \"cpu\": \"2\"\n    \"memory\": \"2Gi\"\n\"singleNode\": true\n")
+	expectedHelmValues := "\"extraEnvs\":\n- \"name\": \"OPENSEARCH_INITIAL_ADMIN_PASSWORD\"\n  \"value\": \"OpenSearchAtl1234!\"\n- \"name\": \"plugins.security.ssl.http.enabled\"\n  \"value\": \"false\"\n\"resources\":\n  \"requests\":\n    \"cpu\": \"2\"\n    \"memory\": \"2Gi\"\n\"singleNode\": true\n"
 	assert.Equal(t, expectedHelmValues, values)
 }
 

--- a/test/unittest/confluence_test.go
+++ b/test/unittest/confluence_test.go
@@ -1,6 +1,7 @@
 package unittest
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -23,6 +24,15 @@ func TestConfluenceVariablesPopulatedWithValidValues(t *testing.T) {
 	assert.Equal(t, "confluence", confluence.AttributeValues["chart"])
 	assert.Equal(t, float64(testTimeout*60), confluence.AttributeValues["timeout"])
 	assert.Equal(t, "https://atlassian.github.io/data-center-helm-charts", confluence.AttributeValues["repository"])
+
+	opensearch := plan.ResourcePlannedValuesMap["helm_release.opensearch[0]"]
+	assert.Equal(t, "deployed", opensearch.AttributeValues["status"])
+	assert.Equal(t, "opensearch", opensearch.AttributeValues["chart"])
+	assert.Equal(t, "https://opensearch-project.github.io/helm-charts/", opensearch.AttributeValues["repository"])
+
+	values := opensearch.AttributeValues["values"].([]interface{})[0].(string)
+	expectedHelmValues := fmt.Sprintf("\"extraEnvs\":\n- \"name\": \"OPENSEARCH_INITIAL_ADMIN_PASSWORD\"\n  \"value\": \"OpenSearchAtl1234!\"\n- \"name\": \"plugins.security.ssl.http.enabled\"\n  \"value\": \"false\"\n\"resources\":\n  \"requests\":\n    \"cpu\": \"2\"\n    \"memory\": \"2Gi\"\n\"singleNode\": true\n")
+	assert.Equal(t, expectedHelmValues, values)
 }
 
 func TestConfluenceVariablesPopulatedWithInvalidValues(t *testing.T) {
@@ -112,8 +122,11 @@ var ConfluenceCorrectVariables = map[string]interface{}{
 		"max_heap":   "1024m",
 		"stack_size": "1024k",
 	},
-	"enable_synchrony":         false,
-	"db_snapshot_build_number": "1234",
-	"termination_grace_period": 0,
-	"additional_jvm_args": 			[]string{},
+	"enable_synchrony":           false,
+	"db_snapshot_build_number":   "1234",
+	"termination_grace_period":   0,
+	"additional_jvm_args":        []string{},
+	"opensearch_enabled":         true,
+	"opensearch_requests_cpu":    "2",
+	"opensearch_requests_memory": "2Gi",
 }

--- a/variables.tf
+++ b/variables.tf
@@ -734,6 +734,23 @@ variable "confluence_additional_jvm_args" {
   type        = list(string)
 }
 
+variable "confluence_opensearch_enabled" {
+  description = "If true, OpenSearch will be enabled."
+  type        = bool
+  default     = false
+}
+
+variable "confluence_opensearch_requests_cpu" {
+  description = "The minimum CPU compute to request for the OpenSearch instance"
+  type        = string
+  default     = "1"
+}
+
+variable "confluence_opensearch_requests_memory" {
+  description = "The minimum amount of memory to allocate to the OpenSearch instance"
+  type        = string
+  default     = "1Gi"
+}
 ################################################################################
 # Bitbucket Variables
 ################################################################################


### PR DESCRIPTION
## Pull request description

This PR added support to use OpenSearch for Confluence. 

Control whether to switch OpenSearch on or off by `confluence_opensearch_enabled` in root variable. Also made OpenSearch pod resource configurable. 

## Checklist
- [ ] I have successful end to end tests run (with & without domain)
- [ ] I have added unit tests (if applicable)
- [ ] I have user documentation (if applicable)
