### PR TITLE
Pin helm provider version for nfs module

### DIFF
--- a/modules/AWS/nfs/provider_version.tf
+++ b/modules/AWS/nfs/provider_version.tf
@@ -7,7 +7,7 @@ terraform {
       version = "~> 2.7"
     }
     helm = {
-      version = "~> 2.4"
+      version = "~> 2.12.1"
     }
   }
 }


### PR DESCRIPTION
Terratest copies all modules to a tmp folder and runs terraform plan on them. Since 2.13.0 (https://github.com/hashicorp/terraform-provider-helm/pull/1326/files) they are explicitly checking if helm chart directory exists. We need to pin helm provider version for nfs module to fix unit tests (see [failures](https://github.com/atlassian-labs/data-center-terraform/actions/runs/8641517529/job/23691159751#step:7:17081)) See: [version constraints](https://developer.hashicorp.com/terraform/language/expressions/version-constraints#-3).

## Checklist
- [ ] I have successful end to end tests run (with & without domain)
- [ ] I have added unit tests (if applicable)
- [ ] I have user documentation (if applicable)
