### PR TITLE
hotfix for crowdstrike installation

### DIFF
--- a/modules/AWS/eks/nodegroup_launch_template/templates/crowdstrike/crowdstrike.sh.tpl
+++ b/modules/AWS/eks/nodegroup_launch_template/templates/crowdstrike/crowdstrike.sh.tpl
@@ -24,8 +24,8 @@ crowdstrike_cid_and_token=$(aws secretsmanager get-secret-value \
         --output text \
         2>&1)
 
-crowdstrike_cid=$(echo "$${crowdstrike_cid_and_token}" | jq -r '.cid')
-crowdstrike_token=$(echo "$${crowdstrike_cid_and_token}" | jq -r '.token')
+crowdstrike_cid=$(echo "${crowdstrike_cid_and_token}" | jq -r '.cid')
+crowdstrike_token=$(echo "${crowdstrike_cid_and_token}" | jq -r '.token')
 
 # register agent to CrowdStrike console
 agent_tags="non-micros,non-micros/dev,non-micros/dev/dcapt"


### PR DESCRIPTION
## Pull request description

```
sh-4.2$ echo "$${crowdstrike_cid_and_token}" | jq -r '.cid'
jq: error (at <stdin>:1): Cannot index number with string "cid"
parse error: Invalid numeric literal at line 1, column 31
sh-4.2$ echo "${crowdstrike_cid_and_token}" | jq -r '.cid'
XXX_CORRECT_VALUE_XXX
```

## Checklist
- [ ] I have successful end to end tests run (with & without domain)
- [ ] I have added unit tests (if applicable)
- [ ] I have user documentation (if applicable)
