### PR TITLE
Expect 3 or more online agents in Bamboo e2e tests

### DIFF
--- a/test/e2etest/bamboo_test.go
+++ b/test/e2etest/bamboo_test.go
@@ -54,21 +54,18 @@ func assertBambooProjects(t *testing.T, productUrl string) {
 	assert.Contains(t, string(content), "totalRecords: 1")
 }
 
-func assertRemoteAgentList(t *testing.T, productUrl string) {
+func assertRemoteAgentList(t *testing.T, testConfig TestConfig, productUrl string) {
 	agentUrl := "admin/agent/configureAgents!doDefault.action"
-	// Wait 20 seconds to allow remote agents get online
 	time.Sleep(20 * time.Second)
 	url := fmt.Sprintf("%s/%s", productUrl, agentUrl)
-	content := getPageContentWithBasicAuth(t, url, "recovery_admin", "temporarypassword")
+	content := getPageContentWithBasicAuth(t, url, "admin", testConfig.BambooPassword)
 	println("Asserting Bamboo RemoteAgentList...")
 	r := regexp.MustCompile(`(?s)There are currently\s+(\d+)\s+remote agents online`)
 	matches := r.FindStringSubmatch(string(content))
 	assert.NotEmpty(t, matches, "Expected to find a match for 'There are currently X remote agents online' but none was found")
-	if len(matches) > 1 {
-		numAgents, err := strconv.Atoi(matches[1])
-		assert.NoError(t, err, "Failed to convert the number of agents to an integer")
-		assert.GreaterOrEqual(t, numAgents, 3, "The number of remote agents should be greater than 0")
-	}
+	numAgents, err := strconv.Atoi(matches[1])
+	assert.NoError(t, err, "Failed to convert the number of agents to an integer")
+	assert.GreaterOrEqual(t, numAgents, 3, "The number of remote agents should be greater than 3")
 }
 
 func resumeBambooServer(t *testing.T, testConfig TestConfig, productUrl string) {


### PR DESCRIPTION
Starting from 9.6.1 old offline agents aren't removed from the db instantly. As a result, e2e fail to assert there are exactly 3 agents because there can be more:

![image](https://github.com/atlassian-labs/data-center-terraform/assets/52448429/cfe38999-7f08-49e2-9b89-232bce7279ae)

It's better to assert there are 3 or more agents.

## Checklist
- [x] I have successful end to end tests run (with & without domain)