### PR TITLE
Add extra tags to LB created for Nginx svc

### DIFF
--- a/dc-infrastructure.tf
+++ b/dc-infrastructure.tf
@@ -19,8 +19,6 @@ module "base-infrastructure" {
   enable_https_ingress      = var.enable_https_ingress
   create_external_dns       = var.create_external_dns
   additional_namespaces     = var.additional_namespaces
-  resource_tags             = var.resource_tags
-
   enable_ssh_tcp        = local.install_bitbucket
   osquery_secret_name   = var.osquery_fleet_enrollment_secret_name
   osquery_secret_region = var.osquery_fleet_enrollment_secret_region_aws

--- a/modules/AWS/ingress/locals.tf
+++ b/modules/AWS/ingress/locals.tf
@@ -5,7 +5,7 @@ locals {
   domain_supplied      = var.ingress_domain != null ? true : false
   enable_https_ingress = var.enable_https_ingress
   nat_ip_cidr          = var.load_balancer_access_ranges == ["0.0.0.0/0"] ? [] : formatlist("%s/32", var.vpc.nat_public_ips)
-  resource_tags        = join(", ", [for k, v in var.resource_tags : "${k}=${v}"])
+  resource_tags        = join(", ", [for k, v in var.tags : "${k}=${v}"])
 
   ssh_tcp_setting = var.enable_ssh_tcp ? yamlencode({
     tcp = {

--- a/modules/AWS/ingress/variables.tf
+++ b/modules/AWS/ingress/variables.tf
@@ -36,7 +36,7 @@ variable "additional_namespaces" {
   default     = []
 }
 
-variable "resource_tags" {
+variable "tags" {
   description = "Additional tags for all resources to be created."
   type = map(string)
 }

--- a/modules/common/main.tf
+++ b/modules/common/main.tf
@@ -49,7 +49,7 @@ module "ingress" {
   enable_https_ingress        = var.enable_https_ingress
   vpc                         = module.vpc
   additional_namespaces       = var.additional_namespaces
-  resource_tags               = var.resource_tags
+  tags                        = var.tags
 }
 
 module "external_dns" {

--- a/modules/common/variables.tf
+++ b/modules/common/variables.tf
@@ -237,8 +237,3 @@ variable "test_deployment_image_tag" {
   type        = string
   default     = "24.0.7-dind"
 }
-
-variable "resource_tags" {
-  description = "Additional tags for all resources to be created."
-  type = map(string)
-}

--- a/test/unittest/ingress_test.go
+++ b/test/unittest/ingress_test.go
@@ -21,7 +21,7 @@ func TestIngressIsCreatedWithDomain(t *testing.T) {
 		"enable_ssh_tcp":              true,
 		"load_balancer_access_ranges": []string{"0.0.0.0/0"},
 		"enable_https_ingress":        bool(false),
-		"resource_tags": map[string]interface{}{
+		"tags": map[string]interface{}{
 			"environment": "development",
 			"project":     "deplops",
 			"owner":       "team-a",
@@ -66,7 +66,7 @@ func TestIngressIsCreatedWithoutDomain(t *testing.T) {
 		},
 		"load_balancer_access_ranges": []string{"0.0.0.0/0"},
 		"enable_https_ingress":        bool(false),
-		"resource_tags": map[string]interface{}{
+		"tags": map[string]interface{}{
 			"environment": "development",
 			"project":     "deplops",
 			"owner":       "team-a",

--- a/test/unittest/test_variables.go
+++ b/test/unittest/test_variables.go
@@ -343,7 +343,7 @@ var IngressInvalidVariablesValue = map[string]interface{}{
 	"vpc": map[string]interface{}{
 		"nat_public_ips": []string{"1.1.1.1", "2.2.2.2"},
 	},
-	"resource_tags": map[string]interface{}{
+	"tags": map[string]interface{}{
 		"environment": "development",
 		"project":     "deplops",
 		"owner":       "team-a",
@@ -359,7 +359,7 @@ var IngressValidVariablesValue = map[string]interface{}{
 	"vpc": map[string]interface{}{
 		"nat_public_ips": []string{"1.1.1.1", "2.2.2.2"},
 	},
-	"resource_tags": map[string]interface{}{
+	"tags": map[string]interface{}{
 		"environment": "development",
 		"project":     "deplops",
 		"owner":       "team-a",


### PR DESCRIPTION
Since it's not Terraform that explicitly creates a LoadBalancer but AWS controller, it's good to pass resource_tags in the svc annotation so that AWS controller adds extra tags to the LB.

Also, bump ingress nginx helm chart version to the latest as of today.

## Checklist
- [x] I have successful end to end tests run (with & without domain)
