### PR TITLE
Improve error message in case upper-case chars in env name

### DIFF
--- a/modules/AWS/s3/variables.tf
+++ b/modules/AWS/s3/variables.tf
@@ -8,7 +8,7 @@ variable "bucket_name" {
   description = "Name of the bucket to store the terraform state"
   validation {
     condition     = can(regex("^[a-z0-9][a-z0-9-]{0,61}[a-z0-9]$", var.bucket_name))
-    error_message = "Invalid S3 bucket name. Valid name is up to 63 characters starting with alphabet and followed by alphanumerics. '-' is allowed as well."
+    error_message = "Invalid S3 bucket name. Valid name is up to 63 characters starting with lower-case only alphabet and followed by lower-case alphanumerics. '-' and '.' are allowed as well."
   }
 }
 
@@ -17,6 +17,6 @@ variable "logging_bucket" {
   description = "Name of the bucket to store the logs"
   validation {
     condition     = var.logging_bucket == null || can(regex("^[a-z0-9][a-z0-9-]{0,61}[a-z0-9]$", var.logging_bucket))
-    error_message = "Invalid logging bucket name. Valid name is up to 63 characters starting with alphabet and followed by alphanumerics. '-' is allowed as well."
+    error_message = "Invalid logging bucket name. Valid name is up to 63 characters starting with lower-case only alphabet and  followed by lower-case alphanumerics. '-' and '.' are allowed as well."
   }
 }


### PR DESCRIPTION
Improve error message in case upper-case characters in the environment name.

S3 bucket name policy:
Only lowercase letters, numbers, dashes, and dots are allowed in S3 bucket names. Bucket names must be three to 63 characters in length, must begin and end with a number or letter, and cannot be in an IP address format.

## Pull request description

_Provide description for the PR_

## Checklist
- [ ] I have successful end to end tests run (with & without domain)
- [ ] I have added unit tests (if applicable)
- [ ] I have user documentation (if applicable)
