### PR TITLE
CLIP-1883: Role permissions

### DIFF
--- a/permissions/assume-role.sh
+++ b/permissions/assume-role.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+
+# This script is useful when you want to do role chaining.
+# Make sure you've already authenticated into AWS CLI before running this script.
+# Replace accountId and roleName with the actual values.
+# Run this script by executing `source assume-role.sh` in the terminal, otherwise change won't be propagated to the parent shell.
+
+unset AWS_ACCESS_KEY_ID
+unset AWS_SECRET_ACCESS_KEY
+unset AWS_SESSION_TOKEN
+
+ROLE_DATA=$(aws sts assume-role --role-arn arn:aws:iam::accountId:role/roleName --role-session-name terraform-policy)
+
+export AWS_ACCESS_KEY_ID=$(echo $ROLE_DATA | jq ".Credentials.AccessKeyId" | sed 's/"//g')
+export AWS_SECRET_ACCESS_KEY=$(echo $ROLE_DATA | jq ".Credentials.SecretAccessKey" | sed 's/"//g')
+export AWS_SESSION_TOKEN=$(echo $ROLE_DATA | jq ".Credentials.SessionToken" | sed 's/"//g')
+
+ASSUMED_ROLE=$(aws sts get-caller-identity | jq ".Arn" | sed 's/"//g')
+echo "You're assumed role ${ASSUMED_ROLE}"

--- a/permissions/policy.json
+++ b/permissions/policy.json
@@ -273,12 +273,7 @@
         "arn:aws:iam::123456789012:policy/*-s3-confluence-storage-policy",
         "arn:aws:iam::123456789012:policy/*_ExternalDNS",
         "arn:aws:iam::123456789012:oidc-provider/*",
-        "arn:aws:iam::123456789012:role/aws-service-role/eks-nodegroup.amazonaws.com/AWSServiceRoleForAmazonEKSNodegroup",
-        "arn:aws:iam::123456789012:policy/*_crowdstrike_s3",
-        "arn:aws:iam::123456789012:policy/*_crowdstrike_secret",
-        "arn:aws:iam::123456789012:policy/*_LaaS-policy",
-        "arn:aws:iam::123456789012:policy/*_Fleet-Enrollment"
-
+        "arn:aws:iam::123456789012:role/aws-service-role/eks-nodegroup.amazonaws.com/AWSServiceRoleForAmazonEKSNodegroup"
       ]
     }
   ]

--- a/permissions/policy.json
+++ b/permissions/policy.json
@@ -1,0 +1,285 @@
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Sid": "sts",
+      "Effect": "Allow",
+      "Action": [
+        "sts:GetCallerIdentity"
+      ],
+      "Resource": "*"
+    },
+    {
+      "Sid": "route53",
+      "Effect": "Allow",
+      "Action": [
+        "route53:DeleteHostedZone",
+        "route53:GetChange",
+        "route53:ListResourceRecordSets",
+        "route53:ChangeResourceRecordSets",
+        "route53:GetHostedZone",
+        "route53:ListHostedZones",
+        "route53:CreateHostedZone",
+        "route53:ChangeTagsForResource",
+        "route53:ListTagsForResource"
+      ],
+      "Resource": "*"
+    },
+    {
+      "Sid": "cert",
+      "Effect": "Allow",
+      "Action": [
+        "acm:DeleteCertificate",
+        "acm:DescribeCertificate",
+        "acm:RequestCertificate",
+        "acm:AddTagsToCertificate",
+        "acm:ListTagsForCertificate",
+        "acm:RemoveTagsFromCertificate"
+      ],
+      "Resource": "arn:aws:acm:*:123456789012:certificate/*"
+    },
+    {
+      "Sid": "elb",
+      "Effect": "Allow",
+      "Action": [
+        "elasticloadbalancing:DescribeLoadBalancers",
+        "elasticloadbalancing:DescribeLoadBalancerAttributes",
+        "elasticloadbalancing:DescribeTags",
+        "elasticloadbalancing:AddTags",
+        "elasticloadbalancing:RemoveTags"
+      ],
+      "Resource": "*"
+    },
+    {
+      "Sid": "eks",
+      "Effect": "Allow",
+      "Action": [
+        "eks:DescribeCluster",
+        "eks:DeleteCluster",
+        "eks:DescribeNodegroup",
+        "eks:DescribeAddon",
+        "eks:DeleteNodegroup",
+        "eks:DeleteAddon",
+        "eks:CreateAddon",
+        "eks:CreateNodegroup",
+        "eks:CreateCluster",
+        "eks:TagResource",
+        "eks:UntagResource",
+        "eks:ListTagsForResource"
+      ],
+      "Resource": [
+        "arn:aws:eks:*:123456789012:nodegroup/atlas-*",
+        "arn:aws:eks:*:123456789012:cluster/atlas-*-cluster",
+        "arn:aws:eks:*:123456789012:addon/*"
+      ]
+    },
+    {
+      "Sid": "DynamoDB",
+      "Effect": "Allow",
+      "Action": [
+        "dynamodb:DeleteTable",
+        "dynamodb:DescribeTimeToLive",
+        "dynamodb:DescribeTable",
+        "dynamodb:DescribeContinuousBackups",
+        "dynamodb:CreateTable",
+        "dynamodb:TagResource",
+        "dynamodb:UntagResource",
+        "dynamodb:ListTagsOfResource",
+        "dynamodb:PutItem",
+        "dynamodb:GetItem",
+        "dynamodb:DeleteItem",
+        "dynamodb:UpdateItem"
+      ],
+      "Resource": [
+        "arn:aws:dynamodb:*:123456789012:table/atl_dc_*_tf_lock"
+      ]
+    },
+    {
+      "Sid": "s3bucket",
+      "Effect": "Allow",
+      "Action": [
+        "s3:DeleteBucket",
+        "s3:GetReplicationConfiguration",
+        "s3:GetLifecycleConfiguration",
+        "s3:GetEncryptionConfiguration",
+        "s3:GetBucketWebsite",
+        "s3:GetBucketVersioning",
+        "s3:GetBucketRequestPayment",
+        "s3:GetBucketObjectLockConfiguration",
+        "s3:GetBucketLogging",
+        "s3:GetBucketCORS",
+        "s3:GetBucketAcl",
+        "s3:GetAccelerateConfiguration",
+        "s3:PutLifecycleConfiguration",
+        "s3:PutEncryptionConfiguration",
+        "s3:PutBucketVersioning",
+        "s3:GetBucketPolicy",
+        "s3:CreateBucket",
+        "s3:GetBucketTagging",
+        "s3:PutBucketTagging",
+        "s3:PutBucketLogging",
+        "s3:PutBucketOwnershipControls",
+        "s3:ListBucket",
+        "s3:ListBucketVersions"
+      ],
+      "Resource": [
+        "arn:aws:s3:::atl-dc-*",
+        "arn:aws:s3:::*-confluence-storage"
+      ]
+    },
+    {
+      "Sid": "s3object",
+      "Effect": "Allow",
+      "Action": [
+        "s3:PutObject",
+        "s3:GetObject",
+        "s3:DeleteObject",
+        "s3:GetObjectTagging",
+        "s3:PutObjectTagging",
+        "s3:DeleteObjectTagging",
+        "s3:PutObjectVersionTagging",
+        "s3:DeleteObjectVersion",
+        "s3:GetObjectVersionAttributes",
+        "s3:GetObjectVersion"
+      ],
+      "Resource": [
+        "arn:aws:s3:::atl-dc-*/*",
+        "arn:aws:s3:::*-confluence-storage/*"
+      ]
+    },
+    {
+      "Sid": "ec2",
+      "Effect": "Allow",
+      "Action": [
+        "ec2:DescribeVpcs",
+        "ec2:DeleteVpc",
+        "ec2:DeleteSecurityGroup",
+        "ec2:RevokeSecurityGroupEgress",
+        "ec2:DeleteSubnet",
+        "ec2:DeleteLaunchTemplate",
+        "ec2:DescribeSecurityGroupRules",
+        "ec2:DescribeNatGateways",
+        "ec2:DescribeLaunchTemplates",
+        "ec2:DescribeLaunchTemplateVersions",
+        "ec2:DescribeSubnets",
+        "ec2:DescribeInternetGateways",
+        "ec2:DescribeAddresses",
+        "ec2:DescribeVpcAttribute",
+        "ec2:DescribeRouteTables",
+        "ec2:DescribeNetworkAcls",
+        "ec2:DescribeVpcClassicLinkDnsSupport",
+        "ec2:DescribeVpcClassicLink",
+        "ec2:DescribeAvailabilityZones",
+        "ec2:ReleaseAddress",
+        "ec2:DisassociateAddress",
+        "ec2:DeleteInternetGateway",
+        "ec2:DetachInternetGateway",
+        "ec2:DisassociateRouteTable",
+        "ec2:DeleteRouteTable",
+        "ec2:DeleteNatGateway",
+        "ec2:DeleteRoute",
+        "ec2:RunInstances",
+        "ec2:CreateRoute",
+        "ec2:CreateNatGateway",
+        "ec2:AssociateRouteTable",
+        "ec2:AuthorizeSecurityGroupEgress",
+        "ec2:AuthorizeSecurityGroupIngress",
+        "ec2:CreateSecurityGroup",
+        "ec2:ModifySubnetAttribute",
+        "ec2:CreateSubnet",
+        "ec2:CreateRouteTable",
+        "ec2:CreateInternetGateway",
+        "ec2:AttachInternetGateway",
+        "ec2:ModifyVpcAttribute",
+        "ec2:CreateVpc",
+        "ec2:CreateLaunchTemplate",
+        "ec2:AllocateAddress",
+        "ec2:DeleteTags",
+        "ec2:DescribeTags",
+        "ec2:CreateTags",
+        "ec2:CreateVolume",
+        "ec2:DescribeVolumes",
+        "ec2:DeleteVolume",
+        "ec2:DescribeSnapshots",
+        "ec2:DescribeSecurityGroups",
+        "ec2:DescribeNetworkInterfaces",
+        "ec2:RevokeSecurityGroupIngress"
+      ],
+      "Resource": "*"
+    },
+    {
+      "Sid": "rds",
+      "Effect": "Allow",
+      "Action": [
+        "rds:CreateDBSubnetGroup",
+        "rds:DescribeDBSubnetGroups",
+        "rds:DeleteDBSubnetGroup",
+        "rds:CreateDBInstance",
+        "rds:DescribeDBInstances",
+        "rds:DeleteDBInstance",
+        "rds:DescribeDBSnapshots",
+        "rds:RestoreDBInstanceFromDBSnapshot",
+        "rds:ListTagsForResource",
+        "rds:AddTagsToResource",
+        "rds:RemoveTagsFromResource",
+        "rds:ModifyDBInstance"
+      ],
+      "Resource": "*"
+    },
+    {
+      "Sid": "autoscaling",
+      "Effect": "Allow",
+      "Action": [
+        "autoscaling:CreateOrUpdateTags",
+        "autoscaling:DeleteTags",
+        "autoscaling:DescribeTags"
+      ],
+      "Resource": "*"
+    },
+    {
+      "Sid": "iam",
+      "Effect": "Allow",
+      "Action": [
+        "iam:ListRolePolicies",
+        "iam:ListAttachedRolePolicies",
+        "iam:DeleteRole",
+        "iam:ListInstanceProfilesForRole",
+        "iam:DetachRolePolicy",
+        "iam:GetRole",
+        "iam:GetPolicy",
+        "iam:GetOpenIDConnectProvider",
+        "iam:DeletePolicy",
+        "iam:ListPolicyVersions",
+        "iam:DeleteOpenIDConnectProvider",
+        "iam:GetPolicyVersion",
+        "iam:AttachRolePolicy",
+        "iam:CreateRole",
+        "iam:CreatePolicy",
+        "iam:CreateOpenIDConnectProvider",
+        "iam:PassRole",
+        "iam:TagRole",
+        "iam:TagPolicy",
+        "iam:TagOpenIDConnectProvider",
+        "iam:UntagRole",
+        "iam:UntagPolicy",
+        "iam:UntagOpenIDConnectProvider"
+      ],
+      "Resource": [
+        "arn:aws:iam::123456789012:role/*-autoscaler",
+        "arn:aws:iam::123456789012:role/*-s3-storage-role",
+        "arn:aws:iam::123456789012:role/atlas-*",
+        "arn:aws:iam::123456789012:role/*-external-dns",
+        "arn:aws:iam::123456789012:policy/cluster-autoscaler*",
+        "arn:aws:iam::123456789012:policy/*-s3-confluence-storage-policy",
+        "arn:aws:iam::123456789012:policy/*_ExternalDNS",
+        "arn:aws:iam::123456789012:oidc-provider/*",
+        "arn:aws:iam::123456789012:role/aws-service-role/eks-nodegroup.amazonaws.com/AWSServiceRoleForAmazonEKSNodegroup",
+        "arn:aws:iam::123456789012:policy/*_crowdstrike_s3",
+        "arn:aws:iam::123456789012:policy/*_crowdstrike_secret",
+        "arn:aws:iam::123456789012:policy/*_LaaS-policy",
+        "arn:aws:iam::123456789012:policy/*_Fleet-Enrollment"
+
+      ]
+    }
+  ]
+}

--- a/permissions/test-permission.md
+++ b/permissions/test-permission.md
@@ -1,0 +1,8 @@
+# How to test AWS permissions
+1. Create a new IAM role in the AWS console
+2. Create a new IAM policy in the AWS console using the statements in `policy.json` (replace `123456789012` with your account id)
+3. Attach the policy to the role
+4. Update role arn in `assume-role.sh` and run it if you're assuming role using role chaining. 
+5. Run `install.sh` and `uninstall.sh` to deploy and destroy resources.
+6. Add in actions missing into `policy.json` and run `update-policy.sh` to update the policy.
+7. Repeat steps 4-6 until the policy is correct.

--- a/permissions/update-policy.sh
+++ b/permissions/update-policy.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+
+# This script is used for updating a policy with a new version
+# It'll try creating a new version first, it failed due to the policy version limit, it'll delete the old versions and retry creating the new version
+# Update policy_arn and policy_document_path with the actual values
+policy_arn="arn:aws:iam::accountId:policy/policyName"
+policy_document_path="./policy.json"
+
+# Attempt to create a new policy version and capture the output and error
+output=$(aws iam create-policy-version \
+    --policy-arn "$policy_arn" \
+    --policy-document file://"$policy_document_path" --set-as-default 2>&1)
+exit_status=$?
+
+# Check the exit status
+if [ $exit_status -eq 0 ]; then
+  echo "Policy version created successfully"
+else
+  # Check if the output contains the specific error message
+  if echo "$output" | grep -q "A managed policy can have up to 5 versions."; then
+    echo "Policy version number exceeded 5"
+
+    # List all policy versions
+    versions=$(aws iam list-policy-versions --policy-arn "$policy_arn" | jq -r '.Versions[] | select(.IsDefaultVersion == false) | .VersionId')
+
+    # Loop through the versions and delete them
+    for version in $versions; do
+      aws iam delete-policy-version --policy-arn "$policy_arn" --version-id "$version"
+      echo "Deleted policy version $version"
+    done
+
+    # Retry creating the policy version
+    retry_output=$(aws iam create-policy-version \
+        --policy-arn "$policy_arn" \
+        --policy-document file://"$policy_document_path" --set-as-default 2>&1)
+    retry_exit_status=$?
+    if [ $retry_exit_status -eq 0 ]; then
+      echo "Policy version created successfully after deletion"
+    else
+      echo "Failed to create policy version after deletion: $retry_output"
+    fi
+  else
+    echo "An unexpected error occurred: $output"
+  fi
+fi

--- a/test/unittest/snapshots_test.go
+++ b/test/unittest/snapshots_test.go
@@ -181,6 +181,10 @@ func TestSnapshotsFromJson(t *testing.T) {
 	exampleFolder := testStructure.CopyTerraformFolderToTemp(t, "../..", "")
 	awsRegion := aws.GetRandomStableRegion(t, nil, nil)
 	planFilePath := filepath.Join(exampleFolder, "plan.out")
+	vars["jira_version_tag"] = dcSnapshots.Jira.Versions[0].Version
+	vars["confluence_version_tag"] = dcSnapshots.Confluence.Versions[0].Version
+	vars["bitbucket_version_tag"] = dcSnapshots.Bitbucket.Versions[0].Version
+	vars["crowd_version_tag"] = dcSnapshots.Crowd.Versions[0].Version
 	tfOptions := terraform.WithDefaultRetryableErrors(t, &terraform.Options{
 		TerraformDir: exampleFolder,
 		Vars:         vars,


### PR DESCRIPTION
## Pull request description

This PR provided a guided set of policy statements for the AWS IAM role that runs the Terraform deployment. With more clearly defined services and actions in the policy, users no longer need admin permission for the deployment. 

Also, two scripts are added to facilitate testing for future use, i.e. script to assume a role, and script to update policy statement using CLI and policy document instead of doing the update manually via AWS console.  

## Checklist
- [ ] I have successful end to end tests run (with & without domain)
- [ ] I have added unit tests (if applicable)
- [ ] I have user documentation (if applicable)
