### PR TITLE
Fix missing permissions: dynamodb:ListTables

### DIFF
--- a/permissions/policy1.json
+++ b/permissions/policy1.json
@@ -92,6 +92,7 @@
         "dynamodb:DescribeTable",
         "dynamodb:DescribeContinuousBackups",
         "dynamodb:CreateTable",
+        "dynamodb:ListTables",
         "dynamodb:TagResource",
         "dynamodb:UntagResource",
         "dynamodb:ListTagsOfResource",
@@ -101,7 +102,7 @@
         "dynamodb:UpdateItem"
       ],
       "Resource": [
-        "arn:aws:dynamodb:*:123456789012:table/atl_dc_*_tf_lock"
+        "arn:aws:dynamodb:*:123456789012:table/*"
       ]
     },
     {


### PR DESCRIPTION
## Pull request description

Terminate scrips has list dynamodb tables operation: 
https://github.com/atlassian/dc-app-performance-toolkit/blob/dev/app/util/k8s/terminate_cluster.py#L956C16-L956C45

Also, this command fails if there is resource restriction.


## Checklist
- [ ] I have successful end to end tests run (with & without domain)
- [ ] I have added unit tests (if applicable)
- [ ] I have user documentation (if applicable)
