### PR TITLE
Fix terraform version check

### DIFF
--- a/.github/workflows/e2e-test-no-domain.yaml
+++ b/.github/workflows/e2e-test-no-domain.yaml
@@ -50,7 +50,7 @@ jobs:
       - name: Install the latest Terraform
         run: |
           # check existing version
-          terraform -version
+          terraform -version || true
           # download the latest
           URL=$(curl -fsSL https://api.releases.hashicorp.com/v1/releases/terraform/latest | jq -r '.builds[] | select((.arch=="amd64") and (.os=="linux")).url')
           curl -s -o /tmp/terraform.zip ${URL}

--- a/.github/workflows/e2e-test-with-domain.yaml
+++ b/.github/workflows/e2e-test-with-domain.yaml
@@ -50,7 +50,7 @@ jobs:
       - name: Install the latest Terraform
         run: |
           # check existing version
-          terraform -version
+          terraform -version || true
           # download the latest
           URL=$(curl -fsSL https://api.releases.hashicorp.com/v1/releases/terraform/latest | jq -r '.builds[] | select((.arch=="amd64") and (.os=="linux")).url')
           curl -s -o /tmp/terraform.zip ${URL}


### PR DESCRIPTION
GitHub has updated ubuntu-latest (now noble) which has broken e2e workflow.Terraform isn't bundled now so checking tf version fails.