### PR TITLE
Append Gi to local home PV and PVC capacity

### DIFF
--- a/modules/products/confluence/helm.tf
+++ b/modules/products/confluence/helm.tf
@@ -68,7 +68,7 @@ resource "helm_release" "confluence" {
             create = true
             resources = {
               requests = {
-                storage = var.local_home_snapshot_id != null ? "${data.aws_ebs_snapshot.local_home_snapshot[0].volume_size}Gi" : var.local_home_size
+                storage = var.local_home_size
               }
             }
           }

--- a/modules/products/confluence/local_home_storage.tf
+++ b/modules/products/confluence/local_home_storage.tf
@@ -23,7 +23,7 @@ resource "kubernetes_persistent_volume" "local_home" {
   spec {
     access_modes = ["ReadWriteOnce"]
     capacity = {
-      storage = "${data.aws_ebs_snapshot.local_home_snapshot[count.index].volume_size}Gi"
+      storage = var.local_home_size
     }
     storage_class_name = local.storage_class
     persistent_volume_source {
@@ -48,7 +48,7 @@ resource "kubernetes_persistent_volume_claim" "local_home" {
     access_modes = ["ReadWriteOnce"]
     resources {
       requests = {
-        storage = "${data.aws_ebs_snapshot.local_home_snapshot[count.index].volume_size}Gi"
+        storage = var.local_home_size
       }
     }
     storage_class_name = local.storage_class

--- a/modules/products/jira/helm.tf
+++ b/modules/products/jira/helm.tf
@@ -57,7 +57,7 @@ resource "helm_release" "jira" {
             create = true
             resources = {
               requests = {
-                storage = var.local_home_snapshot_id != null ? "${data.aws_ebs_snapshot.local_home_snapshot[0].volume_size}Gi" : var.local_home_size
+                storage = var.local_home_size
               }
             }
           }

--- a/modules/products/jira/local_home_storage.tf
+++ b/modules/products/jira/local_home_storage.tf
@@ -23,7 +23,7 @@ resource "kubernetes_persistent_volume" "local_home" {
   spec {
     access_modes = ["ReadWriteOnce"]
     capacity = {
-      storage = "${data.aws_ebs_snapshot.local_home_snapshot[count.index].volume_size}Gi"
+      storage = var.local_home_size
     }
     storage_class_name = local.storage_class
     persistent_volume_source {
@@ -48,7 +48,7 @@ resource "kubernetes_persistent_volume_claim" "local_home" {
     access_modes = ["ReadWriteOnce"]
     resources {
       requests = {
-        storage = "${data.aws_ebs_snapshot.local_home_snapshot[count.index].volume_size}Gi"
+        storage = var.local_home_size
       }
     }
     storage_class_name = local.storage_class


### PR DESCRIPTION
Occasionally it fails with:

```
Error: quantities must match the regular expression '^([+-]?[0-9.]+)([eEinumkKMGTP]*[-+]?[0-9]*)$'
  with module.jira[0].kubernetes_persistent_volume_claim.local_home[0],
  on modules/products/jira/local_home_storage.tf line 41, in resource "kubernetes_persistent_volume_claim" "local_home":
  41: resource "kubernetes_persistent_volume_claim" "local_home" {

```