### PR TITLE
Revert workaround for 439

### DIFF
--- a/.github/workflows/e2e-test-no-domain.yaml
+++ b/.github/workflows/e2e-test-no-domain.yaml
@@ -38,7 +38,7 @@ jobs:
       TF_VAR_crowdstrike_secret_name: ${{ secrets.TF_VAR_CROWDSTRIKE_SECRET_NAME }}
       TF_VAR_crowdstrike_kms_key_name: ${{ secrets.TF_VAR_CROWDSTRIKE_KMS_KEY_NAME }}
       TF_VAR_crowdstrike_aws_account_id: ${{ secrets.TF_VAR_CROWDSTRIKE_AWS_ACCOUNT_ID }}
-      kinesis_log_producers_role_arns: ${{ secrets.TF_VAR_KINESIS_LOG_PRODUCERS_ROLE_ARNS }}
+      TF_VAR_kinesis_log_producers_role_arns: ${{ secrets.TF_VAR_KINESIS_LOG_PRODUCERS_ROLE_ARNS }}
       USE_DOMAIN: "false"
 
     steps:

--- a/.github/workflows/e2e-test-with-domain.yaml
+++ b/.github/workflows/e2e-test-with-domain.yaml
@@ -38,7 +38,7 @@ jobs:
       TF_VAR_crowdstrike_secret_name: ${{ secrets.TF_VAR_CROWDSTRIKE_SECRET_NAME }}
       TF_VAR_crowdstrike_kms_key_name: ${{ secrets.TF_VAR_CROWDSTRIKE_KMS_KEY_NAME }}
       TF_VAR_crowdstrike_aws_account_id: ${{ secrets.TF_VAR_CROWDSTRIKE_AWS_ACCOUNT_ID }}
-      kinesis_log_producers_role_arns: ${{ secrets.TF_VAR_KINESIS_LOG_PRODUCERS_ROLE_ARNS }}
+      TF_VAR_kinesis_log_producers_role_arns: ${{ secrets.TF_VAR_KINESIS_LOG_PRODUCERS_ROLE_ARNS }}
       USE_DOMAIN: "true"
 
     steps:

--- a/test/e2etest/helper.go
+++ b/test/e2etest/helper.go
@@ -195,7 +195,6 @@ func createConfig(t *testing.T, productList []string, useDomain bool, additional
 		vars["domain"] = domain
 		vars["jsm"] = true // This is to cover jsw and jsm in the existing 2 tests to save time and cost.
 	}
-	vars["kinesis_log_producers_role_arns"] = os.Getenv("kinesis_log_producers_role_arns")
 
 	// parse the template
 	tmpl, _ := template.ParseFiles("test-config.tfvars.tmpl")

--- a/test/e2etest/test-config.tfvars.tmpl
+++ b/test/e2etest/test-config.tfvars.tmpl
@@ -31,9 +31,6 @@ instance_types = ["m5.2xlarge"]
 # Domain name base for the ingress controller. The final domain is subdomain within this domain. (eg.: environment.domain.com)
 {{if .domain}}domain = "{{.domain}}"{{end}}
 
-
-kinesis_log_producers_role_arns = {{.kinesis_log_producers_role_arns}}
-
 # Monitoring settings
 monitoring_enabled = true
 monitoring_grafana_expose_lb = true


### PR DESCRIPTION
Revert https://github.com/atlassian-labs/data-center-terraform/pull/439 because https://github.com/hashicorp/terraform/pull/36121 is in 1.10.1 (while 1.10.2 is the latest)

e2e: [with domain](https://github.com/atlassian-labs/data-center-terraform/actions/runs/12303643690), [without domain](https://github.com/atlassian-labs/data-center-terraform/actions/runs/12303641568) (labeling with e2e will use workflows form master, so had to kick them off with on workflow dispatch)

