### PR TITLE
Add missing iam permissions

### DIFF
--- a/permissions/policy2.json
+++ b/permissions/policy2.json
@@ -138,6 +138,7 @@
         "arn:aws:iam::123456789012:role/*-s3-storage-role",
         "arn:aws:iam::123456789012:role/atlas-*",
         "arn:aws:iam::123456789012:role/*-external-dns",
+        "arn:aws:iam::123456789012:policy/atlas-*",
         "arn:aws:iam::123456789012:policy/cluster-autoscaler*",
         "arn:aws:iam::123456789012:policy/*-s3-confluence-storage-policy",
         "arn:aws:iam::123456789012:policy/*_ExternalDNS",


### PR DESCRIPTION
Something must have changed in eks module, so now an additional policy is created. e2e failure [here](https://github.com/atlassian-labs/data-center-terraform/actions/runs/12335280810/job/34442184678#step:13:5771).
