### PR TITLE
Enable basic auth for crowd

### DIFF
--- a/modules/products/crowd/helm.tf
+++ b/modules/products/crowd/helm.tf
@@ -34,7 +34,7 @@ resource "helm_release" "crowd" {
             }
           }
         }
-        additionalJvmArgs = concat(local.dcapt_analytics_property, var.additional_jvm_args, "-Dcom.atlassian.plugins.authentication.basic.auth.filter.force.allow=true")
+        additionalJvmArgs = concat(local.dcapt_analytics_property, var.additional_jvm_args, ["-Dcom.atlassian.plugins.authentication.basic.auth.filter.force.allow=true"])
       }
       volumes = {
         localHome = {


### PR DESCRIPTION
This is required in e2e tests where a user directory is created to test bitbucket-crowd integration.