### PR TITLE
Default EKS version 1.35

### DIFF
--- a/modules/AWS/eks/iam.tf
+++ b/modules/AWS/eks/iam.tf
@@ -48,6 +48,34 @@ resource "aws_iam_role_policy_attachment" "confluence_s3_storage" {
   role       = aws_iam_role.s3_confluence_storage_role[0].name
 }
 
+resource "aws_iam_role" "ebs_csi_driver" {
+  name = "${var.cluster_name}-ebs-csi-driver"
+
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Effect = "Allow"
+        Principal = {
+          Federated = "arn:aws:iam::${local.account_id}:oidc-provider/${local.oicd_provider}"
+        }
+        Action = "sts:AssumeRoleWithWebIdentity"
+        Condition = {
+          StringEquals = {
+            "${local.oicd_provider}:aud" = "sts.amazonaws.com"
+            "${local.oicd_provider}:sub" = "system:serviceaccount:kube-system:ebs-csi-controller-sa"
+          }
+        }
+      }
+    ]
+  })
+}
+
+resource "aws_iam_role_policy_attachment" "ebs_csi_driver" {
+  policy_arn = "arn:aws:iam::aws:policy/service-role/AmazonEBSCSIDriverPolicy"
+  role       = aws_iam_role.ebs_csi_driver.name
+}
+
 resource "aws_iam_role" "node_group" {
   name_prefix = var.cluster_name
 

--- a/modules/AWS/eks/locals.tf
+++ b/modules/AWS/eks/locals.tf
@@ -7,7 +7,7 @@ locals {
 
   autoscaler_version = "9.37.0"
 
-  ami_type = "AL2_x86_64"
+  ami_type = var.eks_version >= "1.33" ? "AL2023_x86_64_STANDARD" : "AL2_x86_64"
 
   cluster_service_ipv4_cidr = "172.20.0.0/16"
 
@@ -18,8 +18,7 @@ locals {
   eks_node_policies = ["arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore",
     "arn:aws:iam::aws:policy/AmazonEKSWorkerNodePolicy",
     "arn:aws:iam::aws:policy/AmazonEC2ContainerRegistryReadOnly",
-    "arn:aws:iam::aws:policy/AmazonEKS_CNI_Policy",
-  "arn:aws:iam::aws:policy/service-role/AmazonEBSCSIDriverPolicy"]
+    "arn:aws:iam::aws:policy/AmazonEKS_CNI_Policy"]
 
 
   use_downtime = var.cluster_downtime_start != null && var.cluster_downtime_stop != null ? true : false

--- a/modules/AWS/eks/main.tf
+++ b/modules/AWS/eks/main.tf
@@ -11,6 +11,7 @@ module "nodegroup_launch_template" {
   tags                            = var.tags
   instance_types                  = var.instance_types
   instance_disk_size              = var.instance_disk_size
+  ami_type                        = local.ami_type
   osquery_secret_name             = var.osquery_secret_name
   osquery_secret_region           = local.osquery_secret_region
   osquery_env                     = var.osquery_env
@@ -41,6 +42,7 @@ module "eks" {
     }
     aws-ebs-csi-driver = {
       resolve_conflicts_on_create = "OVERWRITE"
+      service_account_role_arn    = aws_iam_role.ebs_csi_driver.arn
       configuration_values = jsonencode({
         defaultStorageClass = {
           enabled = true

--- a/modules/AWS/eks/nodegroup_launch_template/locals.tf
+++ b/modules/AWS/eks/nodegroup_launch_template/locals.tf
@@ -43,5 +43,23 @@ locals {
     crowdstrike_secret_name       = var.crowdstrike_secret_name
   })]
 
-  user_data = local.user_content != [] ? base64encode(join("\n", concat(local.user_content, ["--==MYBOUNDARY==--"]))) : null
+  # MIME document preamble shared by both AL2 and AL2023 paths.
+  mime_preamble = "MIME-Version: 1.0\nContent-Type: multipart/mixed; boundary=\"==MYBOUNDARY==\""
+
+  # AL2: standard MIME multipart with shell script parts.
+  # AL2023: a nodeadm YAML config part is inserted before the shell script parts so that
+  #         the node bootstrap agent (nodeadm) can join the cluster. Shell scripts run
+  #         after the node has bootstrapped.
+  #
+  # AL2023 user data format reference:
+  # https://docs.aws.amazon.com/eks/latest/userguide/launch-templates.html#launch-template-user-data
+  nodeadm_part = "--==MYBOUNDARY==\nContent-Type: application/node.eks.aws\n\n---\napiVersion: node.eks.aws/v1alpha1\nkind: NodeConfig\nspec:\n  cluster:\n    name: ${var.cluster_name}"
+
+  is_al2023 = var.ami_type == "AL2023_x86_64_STANDARD"
+
+  user_data = length(local.templates_all) > 0 ? (
+    local.is_al2023
+    ? base64encode(join("\n\n", concat([local.mime_preamble, local.nodeadm_part], local.user_content, ["--==MYBOUNDARY==--"])))
+    : base64encode(join("\n\n", concat([local.mime_preamble], local.user_content, ["--==MYBOUNDARY==--"])))
+  ) : null
 }

--- a/modules/AWS/eks/nodegroup_launch_template/main.tf
+++ b/modules/AWS/eks/nodegroup_launch_template/main.tf
@@ -13,7 +13,7 @@ resource "aws_launch_template" "nodegroup" {
 
     ebs {
       volume_size           = var.instance_disk_size
-      volume_type           = "gp2"
+      volume_type           = "gp3"
       delete_on_termination = true
     }
   }

--- a/modules/AWS/eks/nodegroup_launch_template/templates/crowdstrike/crowdstrike.sh.tpl
+++ b/modules/AWS/eks/nodegroup_launch_template/templates/crowdstrike/crowdstrike.sh.tpl
@@ -5,16 +5,24 @@ Content-Type: text/x-shellscript; charset="us-ascii"
 
 ### CROWDSTRIKE INSTALLATION
 
-sudo yum install -y yum-utils unzip jq
+if command -v dnf &>/dev/null; then
+  PKG_MGR="dnf"
+  RPM_SUFFIX="amzn2023"
+else
+  PKG_MGR="yum"
+  RPM_SUFFIX="amzn2"
+fi
+
+sudo $PKG_MGR install -y yum-utils unzip jq
 curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip"
 unzip awscliv2.zip
 ./aws/install
 
 # fetch falcon sensor rpm
-aws s3 cp s3://trust-shared-agents/crowdstrike/amazon/falcon-sensor-${falcon_sensor_version}.amzn2.x86_64.rpm .
+aws s3 cp s3://trust-shared-agents/crowdstrike/amazon/falcon-sensor-${falcon_sensor_version}.$${RPM_SUFFIX}.x86_64.rpm .
 
 # install falcon sensor
-sudo yum install ./falcon-sensor-${falcon_sensor_version}.amzn2.x86_64.rpm -y
+sudo $PKG_MGR install ./falcon-sensor-${falcon_sensor_version}.$${RPM_SUFFIX}.x86_64.rpm -y
 
 # fetch a secret with cid and token
 crowdstrike_cid_and_token=$(aws secretsmanager get-secret-value \
@@ -35,7 +43,7 @@ sudo systemctl start falcon-sensor.service
 sudo systemctl enable falcon-sensor.service
 
 # verify crowdstrike is running 
-sudo yum list installed | grep falcon-sensor
+sudo $PKG_MGR list installed | grep falcon-sensor
 sudo systemctl is-active falcon-sensor
 sudo systemctl is-enabled falcon-sensor
 

--- a/modules/AWS/eks/nodegroup_launch_template/templates/osquery/osquery.sh.tpl
+++ b/modules/AWS/eks/nodegroup_launch_template/templates/osquery/osquery.sh.tpl
@@ -1,6 +1,3 @@
-MIME-Version: 1.0
-Content-Type: multipart/mixed; boundary="==MYBOUNDARY=="
-
 --==MYBOUNDARY==
 Content-Type: text/x-shellscript; charset="us-ascii"
 
@@ -8,15 +5,21 @@ Content-Type: text/x-shellscript; charset="us-ascii"
 
 ### OSQUERY INSTALLATION
 
-sudo yum install -y yum-utils unzip jq
+if command -v dnf &>/dev/null; then
+  PKG_MGR="dnf"
+else
+  PKG_MGR="yum"
+fi
+
+sudo $PKG_MGR install -y yum-utils unzip jq
 curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip"
 unzip awscliv2.zip
 ./aws/install
 
 curl -L https://pkg.osquery.io/rpm/GPG | sudo tee /etc/pki/rpm-gpg/RPM-GPG-KEY-osquery
-sudo yum-config-manager --add-repo https://pkg.osquery.io/rpm/osquery-s3-rpm.repo
-sudo yum-config-manager --enable osquery-s3-rpm
-sudo yum install -y osquery-${osquery_version}
+sudo $PKG_MGR config-manager --add-repo https://pkg.osquery.io/rpm/osquery-s3-rpm.repo
+sudo $PKG_MGR config-manager --enable osquery-s3-rpm
+sudo $PKG_MGR install -y osquery-${osquery_version}
 
 cat <<'EOF' >> /etc/osquery/osquery.flags
 --force=true
@@ -47,9 +50,9 @@ EOF
 
 aws --region ${osquery_secret_region} secretsmanager get-secret-value --secret-id arn:aws:secretsmanager:${osquery_secret_region}:${account_id}:secret:${osquery_secret_name} | jq -r '.SecretString' > /etc/osquery/fleet.enrollment_secret
 
-# osquery doesn't work with auditd service
-service auditd stop
-chkconfig auditd off
+# osquery doesn't work with auditd service; suppress errors if not present
+service auditd stop 2>/dev/null || true
+chkconfig auditd off 2>/dev/null || true
 
 # Need to make sure osqueryd is started, and that it will automatically start on instance rebooting.
 systemctl start osqueryd

--- a/modules/AWS/eks/nodegroup_launch_template/variables.tf
+++ b/modules/AWS/eks/nodegroup_launch_template/variables.tf
@@ -1,3 +1,8 @@
+variable "ami_type" {
+  description = "AMI type for the EKS node group (e.g. AL2_x86_64 or AL2023_x86_64_STANDARD)."
+  type        = string
+}
+
 variable "cluster_name" {
   description = "Name of the EKS cluster."
   type        = string

--- a/variables.tf
+++ b/variables.tf
@@ -24,7 +24,7 @@ variable "environment_name" {
 
 variable "eks_version" {
   description = "EKS K8s version"
-  default     = "1.33"
+  default     = "1.35"
   type        = string
   validation {
     condition     = can(regex("^1\\.3[0-9]$", var.eks_version))

--- a/variables.tf
+++ b/variables.tf
@@ -24,7 +24,7 @@ variable "environment_name" {
 
 variable "eks_version" {
   description = "EKS K8s version"
-  default     = "1.32"
+  default     = "1.33"
   type        = string
   validation {
     condition     = can(regex("^1\\.3[0-9]$", var.eks_version))


### PR DESCRIPTION
## Pull request description

EKS 1.32 reached end of Standard Support about a week ago and now is in Extended Support mode which costs 6 times more.

This PR bumps default EKS version to 1.35 (Standard Support til March 23, 2027). 

To make it happen it additionally:
- changes AMI type to AL2023_x86_64_STANDARD (since last version where AL2_x86_64 is 1.32)
- creates dedicated IRSA role for the EBS CSI driver addon as the addon version bundled with EKS 1.33+ no longer falls back to the EC2 node instance profile for AWS credentials and requires an explicit IAM role bound to its service account.

## Checklist
- [x] I have successful end to end tests run (with & without domain)
- [x] I have added unit tests (if applicable)
- [x] I have user documentation (if applicable)
