### PR TITLE
Bump osquery to 5.22.1

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -1353,7 +1353,7 @@ variable "osquery_env" {
 variable "osquery_version" {
   description = "Osquery version"
   type        = string
-  default     = "5.14.1"
+  default     = "5.22.1"
 }
 
 variable "osquery_fleet_enrollment_host" {


### PR DESCRIPTION
## Pull request description

This PR bumps default osquery version to 5.22.1

## Checklist
- [ ] I have successful end to end tests run (with & without domain)
- [ ] I have added unit tests (if applicable)
- [ ] I have user documentation (if applicable)
