### PR TITLE
DEVPROD-4024: pin alekc/kubectl provider to <2.3.0 in E2E terraform

### DIFF
--- a/modules/AWS/gateway-api/provider_version.tf
+++ b/modules/AWS/gateway-api/provider_version.tf
@@ -11,7 +11,7 @@ terraform {
     }
     kubectl = {
       source  = "alekc/kubectl"
-      version = "~> 2.0"
+      version = ">= 2.0, < 2.3.0"
     }
   }
 }

--- a/modules/products/bamboo/provider_version.tf
+++ b/modules/products/bamboo/provider_version.tf
@@ -11,7 +11,7 @@ terraform {
     }
     kubectl = {
       source  = "alekc/kubectl"
-      version = "~> 2.0"
+      version = ">= 2.0, < 2.3.0"
     }
   }
 }

--- a/modules/products/bitbucket/provider_version.tf
+++ b/modules/products/bitbucket/provider_version.tf
@@ -11,7 +11,7 @@ terraform {
     }
     kubectl = {
       source  = "alekc/kubectl"
-      version = "~> 2.0"
+      version = ">= 2.0, < 2.3.0"
     }
   }
 }

--- a/modules/products/confluence/provider_version.tf
+++ b/modules/products/confluence/provider_version.tf
@@ -15,7 +15,7 @@ terraform {
     }
     kubectl = {
       source  = "alekc/kubectl"
-      version = "~> 2.0"
+      version = ">= 2.0, < 2.3.0"
     }
   }
 }

--- a/modules/products/crowd/provider_version.tf
+++ b/modules/products/crowd/provider_version.tf
@@ -11,7 +11,7 @@ terraform {
     }
     kubectl = {
       source  = "alekc/kubectl"
-      version = "~> 2.0"
+      version = ">= 2.0, < 2.3.0"
     }
   }
 }

--- a/modules/products/jira/provider_version.tf
+++ b/modules/products/jira/provider_version.tf
@@ -11,7 +11,7 @@ terraform {
     }
     kubectl = {
       source  = "alekc/kubectl"
-      version = "~> 2.0"
+      version = ">= 2.0, < 2.3.0"
     }
   }
 }

--- a/provider_version.tf
+++ b/provider_version.tf
@@ -15,7 +15,7 @@ terraform {
     }
     kubectl = {
       source  = "alekc/kubectl"
-      version = "~> 2.0"
+      version = ">= 2.0, < 2.3.0"
     }
   }
 }


### PR DESCRIPTION
## Pull request description

The E2E pipeline started failing on 2026-05-19 with no code changes on either side, erroring out before EKS was created:

```text
Error: invalid provider configuration: invalid configuration: no configuration has been provided,
try setting KUBERNETES_MASTER environment variable
  with provider["registry.terraform.io/alekc/kubectl"]
```

### Cause

`alekc/terraform-provider-kubectl` `v2.3.x` (released 2026-05-18) removed the silent fallback for incomplete kubeconfig. Since `data-center-terraform` configures the `kubectl` provider from EKS module outputs in the same root module, provider init now fails before the cluster is created. The upstream pin `version = "~> 2.0"` lets `v2.3.x` get picked up automatically.

### Fix

Patch the cloned `data-center-terraform` `provider_version.tf` files in [`e2e-tf-deployment.yaml`](./.github/workflows/e2e-tf-deployment.yaml) to constrain `alekc/kubectl` to `>= 2.0, < 2.3.0`, restoring the previous deferred-config behavior.

### References

- [alekc/terraform-provider-kubectl#283](https://github.com/alekc/terraform-provider-kubectl/issues/283)
- [alekc/terraform-provider-kubectl#264](https://github.com/alekc/terraform-provider-kubectl/pull/264) — regression
- [alekc/terraform-provider-kubectl#284](https://github.com/alekc/terraform-provider-kubectl/pull/284) — `lazy_load` follow-up (future long-term fix)


## Checklist
- [ ] I have successful end to end tests run (with & without domain)
- [ ] I have added unit tests (if applicable)
- [ ] I have user documentation (if applicable)
