### PR TITLE
Fix gateway-api data source kubeconfig in stateless containers

### DIFF
--- a/modules/AWS/gateway-api/main.tf
+++ b/modules/AWS/gateway-api/main.tf
@@ -244,7 +244,7 @@ data "external" "gateway_address" {
   depends_on = [null_resource.wait_for_lb]
 
   program = ["bash", "-c",
-    "printf '{\"hostname\":\"%s\"}' $(kubectl get gateway ${local.gateway_name} -n ${var.namespace} -o jsonpath='{.status.addresses[0].value}')"
+    "aws eks update-kubeconfig --name ${var.cluster_name} --region ${var.region} >/dev/null 2>&1; printf '{\"hostname\":\"%s\"}' $(kubectl get gateway ${local.gateway_name} -n ${var.namespace} -o jsonpath='{.status.addresses[0].value}')"
   ]
 }
 


### PR DESCRIPTION
## Pull request description

Fixes a failure when running install.sh a second time (e.g. scaling bitbucket_replica_count) inside  Docker container, when using Gateway API

Steps to reproduce

1. Set use_gateway_api = "true"
2.  Run install.sh with a Bitbucket config — cluster deploys successfully.
3.  Update config.tfvars to set bitbucket_replica_count = 2.
4.  Run install.sh again inside the Docker container (atlassianlabs/terraform:2.9.21).
5.  Terraform fails with:

Error: Error in function call
  on modules/AWS/gateway-api/main.tf line 252, in data "aws_lb" "gateway_nlb":
 252:   name = regex("^(.+)-[^-]+\\.elb\\.", data.external.gateway_address.result.hostname)[0]
Call to function "regex" failed: pattern did not match any part of the given string.

## Checklist
- [x] I have successful end to end tests run (with & without domain)
- [x] I have added unit tests (if applicable)
- [x] I have user documentation (if applicable)
