### PR TITLE
Bump falcon-sensor; pin terraform-aws-modules/security-group/aws

### DIFF
--- a/modules/AWS/rds/main.tf
+++ b/modules/AWS/rds/main.tf
@@ -3,7 +3,7 @@
 ################################################################################
 module "security_group" {
   source  = "terraform-aws-modules/security-group/aws"
-  version = "~> 4"
+  version = "~> 4, < 6.0.0"
 
   name        = "${var.product}_rds_sg"
   description = "Database security group"

--- a/variables.tf
+++ b/variables.tf
@@ -1406,7 +1406,7 @@ variable "crowdstrike_aws_account_id" {
 variable "falcon_sensor_version" {
   description = "Falcon sensor version"
   type        = string
-  default     = "7.32.0-18504"
+  default     = "7.37.0-19004"
 }
 
 ################################################################################


### PR DESCRIPTION
## Pull request description

Pin terraform-aws-modules/security-group/aws version to < 6.0.0
Bump default falcon-sensor version to 7.37

## Checklist
- [x] I have successful end to end tests run (with & without domain)
- [x] I have added unit tests (if applicable)
- [x] I have user documentation (if applicable)
