### PR TITLE
Remove not used but vulnerable modules

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -30,11 +30,11 @@ RUN apt-get update \
     && apt-get install -y gnupg software-properties-common curl unzip openjdk-17-jdk python3 python3-venv \
     && python3 -m venv /opt/venv \
     && /opt/venv/bin/pip install --upgrade pip \
-    && /opt/venv/bin/pip install boto3 tenacity \
+    && /opt/venv/bin/pip install boto3 \
     && curl -fsSL https://apt.releases.hashicorp.com/gpg | apt-key add - \
     && apt-add-repository "deb [arch=amd64] https://apt.releases.hashicorp.com $(lsb_release -cs) main" \
     && apt-get update && apt-get install -y terraform jq \
-    && apt-get remove -y python3-cryptography \
+    && apt-get remove -y python3-cryptography python3-pip-whl \
     && apt-get clean && rm -rf /var/lib/apt/lists/*
 
 ENV PATH="/opt/venv/bin:$PATH"


### PR DESCRIPTION
## Pull request description

### Problem
Security scanner reported multiple CVEs in the atlassianlabs/terraform Docker image caused by python3-pip-whl — an Ubuntu 24.04 system package pulled in transitively by python3-venv. This package bundles an outdated urllib3 version which triggers the following vulnerability tickets:

•  VULN-1906688 — CVE-2025-66418
•  VULN-1906689 — CVE-2025-66471
•  VULN-1906690 — CVE-2026-21441

Additionally, tenacity was installed in the venv to support the retry logic in terminate_cluster.py (called as a fallback in uninstall.sh when terraform destroy fails). The script has since been rewritten to use a built-in retry decorator with no third-party dependencies, making this package unnecessary.

Changes were tested manually:

•  Built docker.atl-paas.net/dcapt/terraform:main with the updated Dockerfile
•  Verified python3-pip-whl is no longer present in the image (dpkg -l | grep python3-pip-whl)
•  Verified urllib3 2.7.0 is available in the venv via boto3 (/opt/venv/bin/pip show urllib3)
•  Deployed a Jira cluster using install.sh ✅
•  Uninstalled using standard uninstall.sh ✅
•  Verified fallback to terminate_cluster.py works correctly ✅

## Checklist
- [x] I have successful end to end tests run (with & without domain)
- [x] I have added unit tests (if applicable)
- [x] I have user documentation (if applicable)
